### PR TITLE
feat: PitchDocs v1.5.0 — GEO, AI context, docs verification, launch artifacts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pitchdocs",
-  "version": "1.4.1",
-  "description": "Generate high-quality public-facing repository documentation with a marketing edge. Creates READMEs that sell, changelogs that communicate value, roadmaps from GitHub Projects, and audits your docs completeness. Uses benefit-driven language, progressive disclosure, and the Banesullivan 4-question framework.",
+  "version": "1.5.0",
+  "description": "Generate high-quality public-facing repository documentation with a marketing edge. Creates READMEs that sell, changelogs that communicate value, roadmaps from GitHub Projects, AI context files for coding assistants, and audits your docs completeness. Uses benefit-driven language, GEO-optimised structure, progressive disclosure, and the Banesullivan 4-question framework.",
   "author": {
     "name": "Little Bear Apps",
     "email": "hello@littlebearapps.com"
@@ -18,6 +18,11 @@
     "public-docs",
     "contributing",
     "pitchdocs",
-    "little-bear-apps"
+    "little-bear-apps",
+    "seo",
+    "geo",
+    "ai-context",
+    "agents-md",
+    "diataxis"
   ]
 }

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -230,6 +230,17 @@ If a Write or Edit operation returns HTTP 400 "Output blocked by content filteri
 - Do NOT use `--resume` after a filter block — start a fresh generation for that file
 - Do NOT attempt to obfuscate content to bypass the filter — it degrades output quality and is unreliable
 
+## Additional Skills
+
+The following skills extend the documentation suite beyond the core README/CHANGELOG/CONTRIBUTING workflow:
+
+- **`ai-context`** — Generates AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md) from codebase analysis. Use `/ai-context` to generate.
+- **`docs-verify`** — Validates documentation quality, links, freshness, and llms.txt sync. Use `/docs-verify` to run checks.
+- **`launch-artifacts`** — Transforms README/CHANGELOG into platform-specific launch content (Dev.to, Hacker News, Reddit, Twitter/X, awesome list submissions). Use `/launch` to generate.
+- **`api-reference`** — Guidance for setting up API reference documentation generators (TypeDoc, Sphinx, godoc, rustdoc). Use when a project needs automated API docs.
+
+Load these skills on demand when the user requests the corresponding functionality.
+
 ## Output Format
 
 Always write directly to files using Write/Edit tools. Never just output markdown to the chat — write it to the actual files in the repository.
@@ -238,4 +249,5 @@ When generating multiple docs, create them in this order:
 1. README.md (highest impact)
 2. CONTRIBUTING.md (most referenced)
 3. CHANGELOG.md (most maintained)
-4. Others as needed
+4. AI context files (AGENTS.md, CLAUDE.md)
+5. Others as needed

--- a/.claude/rules/doc-standards.md
+++ b/.claude/rules/doc-standards.md
@@ -197,3 +197,104 @@ Format: `[![Badge](https://img.shields.io/...)](link)`
 - `SECURITY.md` — Always uppercase
 - `.github/ISSUE_TEMPLATE/` — GitHub convention
 - `.github/PULL_REQUEST_TEMPLATE.md` — GitHub convention
+
+## GEO: Writing for AI Citation
+
+Generative Engine Optimisation (GEO) ensures documentation surfaces correctly in AI-generated answers — ChatGPT, Perplexity, Google AI Overviews, and Claude. These principles apply to all public-facing docs, not just READMEs.
+
+### Crisp Definitions First
+
+Put a one-sentence definition of the project at the very top of the README, before badges or navigation. LLMs preferentially quote top-of-page definitions when answering "what is X?" queries.
+
+**Pattern:**
+```markdown
+# Project Name
+
+**[One sentence that defines what this project is and who it's for.]**
+```
+
+The definition must be standalone — it should make sense if extracted from the page with no surrounding context.
+
+### Atomic Sections
+
+Each H2 section should have **one clear intent**, answerable as a standalone snippet. AI retrieval systems (RAG) chunk documents by heading, so a section that mixes installation with architecture reduces citation accuracy.
+
+**Rules:**
+- One topic per H2 — don't combine "Features" and "Configuration"
+- Strict heading hierarchy: H1 > H2 > H3 without skipping levels (no H1 > H3)
+- Descriptive headings that contain the topic keyword — "## TypeScript Configuration" not "## Config"
+- Each section should be comprehensible without reading prior sections
+
+### Concrete Statistics
+
+Content with concrete statistics can boost visibility in AI responses by up to 28% (Aggarwal et al., "GEO: Generative Engine Optimization", 2023). Include benchmarks, performance numbers, percentages, and measurable outcomes wherever evidence exists.
+
+**Pattern:**
+```markdown
+- Reduces bundle size by 40% compared to webpack (benchmark: `npm run bench`)
+- Processes 10,000 records/second on a single worker (see `benchmarks/throughput.ts`)
+- 95% test coverage across 200+ test cases (`npm test -- --coverage`)
+```
+
+**Rules:**
+- Every statistic must trace to actual code, a benchmark file, or a verifiable measurement
+- No speculative numbers — "blazingly fast" without evidence is worse than no claim at all
+- Prefer relative comparisons ("40% faster than X") over absolute numbers when the alternative is well-known
+
+### Comparison Tables
+
+LLMs frequently surface comparison tables when answering "X vs Y" or "best X for Y" queries. Structure comparison sections to be extractable:
+
+**Pattern:**
+```markdown
+## How It Compares
+
+| Feature | This Project | Alternative A | Alternative B |
+|---------|-------------|---------------|---------------|
+| Specific feature | :white_check_mark: (with detail) | :x: | Partial |
+```
+
+**Rules:**
+- Use a descriptive H2 heading: "How It Compares" or "How [Project] Compares to [Category]"
+- Be factually accurate about competitors — false claims erode trust with both humans and AI
+- Include at least one quantitative row (speed, bundle size, API count) alongside qualitative ones
+- Link to sources for competitor claims where possible
+
+### TL;DR and Key Concepts Blocks
+
+For long guides (200+ lines), add a **TL;DR** or **Key Concepts** block immediately after the title. RAG systems often extract the first paragraph under a heading — make it count.
+
+**Pattern:**
+```markdown
+# Migration Guide
+
+> **TL;DR:** Upgrade from v1 to v2 by running `npx migrate` — the CLI handles config changes, dependency updates, and breaking API renames automatically. Manual steps are only needed for custom plugins.
+
+## Prerequisites
+...
+```
+
+### Prerequisite Blocks
+
+Explicit, structured prerequisite blocks improve LLM understanding of dependencies and requirements. Always use a consistent format.
+
+**Pattern:**
+```markdown
+## Prerequisites
+
+- Node.js 20+ ([install guide](https://nodejs.org/))
+- npm 10+ (included with Node.js)
+- A GitHub account with repo access
+```
+
+Never bury prerequisites in prose paragraphs — AI extractors miss them.
+
+### Cross-Referencing for Semantic Scaffolding
+
+AI systems build understanding by following links between related documents. Explicit cross-references create a "semantic web" that improves citation accuracy across your documentation set.
+
+**Rules:**
+- Every guide links to at least one related guide and back to the hub page
+- Use descriptive link text — `[Configuration Guide](docs/guides/configuration.md)` not `[click here](link)`
+- README links to docs hub, docs hub links to individual guides, guides link back to README
+- Changelog links to relevant documentation for breaking changes

--- a/.claude/skills/ai-context/SKILL.md
+++ b/.claude/skills/ai-context/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: ai-context
+description: Generates AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md) from codebase analysis. Creates project-specific instructions for AI coding assistants so they understand conventions, architecture, and workflows. Use when setting up AI tool context for a repository.
+---
+
+# AI Context File Generator
+
+## Philosophy
+
+AI coding assistants work better when they understand a project's conventions, architecture, and constraints. Context files tell AI tools **how** to work with the codebase — coding standards, test patterns, import conventions, key file paths, and deployment workflows.
+
+This skill generates context files for multiple AI tools from a single codebase analysis. The same scan produces output for Claude Code, Codex CLI, Cursor, GitHub Copilot, and Gemini CLI.
+
+## Supported Context Files
+
+| File | AI Tool | Purpose | Adoption |
+|------|---------|---------|----------|
+| `AGENTS.md` | Codex CLI, Cursor, Gemini CLI, Claude Code | Cross-tool agent context — identity, capabilities, conventions | 40,000+ repos |
+| `CLAUDE.md` | Claude Code | Project-specific instructions loaded on every session | Native to Claude Code |
+| `.cursorrules` | Cursor | Editor-specific rules for code generation | Native to Cursor |
+| `.github/copilot-instructions.md` | GitHub Copilot | Repository-level instructions for Copilot suggestions | Native to Copilot |
+
+## Codebase Analysis Workflow
+
+### Step 1: Detect Project Profile
+
+```bash
+# Language and runtime
+ls package.json pyproject.toml Cargo.toml go.mod pom.xml build.gradle 2>/dev/null
+
+# Framework detection
+cat package.json 2>/dev/null | grep -E '"(react|next|express|fastify|hono|astro|svelte)"'
+cat pyproject.toml 2>/dev/null | grep -E '(fastapi|django|flask|starlette)'
+
+# Test runner
+ls jest.config* vitest.config* pytest.ini pyproject.toml .mocharc* 2>/dev/null
+grep -l "test" package.json 2>/dev/null
+
+# Linter/formatter
+ls .eslintrc* eslint.config* .prettierrc* biome.json ruff.toml .flake8 2>/dev/null
+
+# TypeScript configuration
+ls tsconfig*.json 2>/dev/null
+
+# Monorepo detection
+ls pnpm-workspace.yaml lerna.json nx.json turbo.json 2>/dev/null
+
+# CI/CD
+ls .github/workflows/*.yml 2>/dev/null
+```
+
+### Step 2: Extract Conventions
+
+From the codebase analysis, extract:
+
+1. **Language version** — Node.js version from `.nvmrc`/`engines`, Python from `requires-python`, Go from `go.mod`
+2. **Import conventions** — ESM vs CommonJS, absolute vs relative imports, path aliases (`@/`)
+3. **Naming patterns** — camelCase/snake_case for variables, PascalCase for types, file naming
+4. **Directory structure** — where source, tests, config, and docs live
+5. **Test patterns** — test file location (`__tests__/`, `*.test.ts`, `tests/`), test runner, assertion style
+6. **Build/deploy** — build command, deploy target (Cloudflare, Vercel, AWS, etc.)
+7. **Error handling** — custom error classes, Result types, try-catch patterns
+8. **Security rules** — .gitignore patterns, secret management, input validation
+
+### Step 3: Generate Context Files
+
+#### AGENTS.md Structure
+
+```markdown
+# AGENTS.md
+
+## Identity
+
+[Project name] is a [brief description]. Built with [language/framework].
+
+## Project Structure
+
+```
+[Key directories and their purpose]
+```
+
+## Coding Conventions
+
+- [Language]: [version]
+- Style: [naming conventions, import order]
+- Types: [strict mode, no any, explicit returns — if TypeScript]
+- Tests: [runner, location, naming pattern]
+- Commits: [conventional commits, branch naming]
+
+## Key Commands
+
+```bash
+[install command]
+[test command]
+[build command]
+[lint command]
+[deploy command]
+```
+
+## Architecture
+
+[2-3 sentences on architecture: patterns used, key abstractions, data flow]
+
+## Important Files
+
+- [key config file] — [purpose]
+- [main entry point] — [purpose]
+- [key module] — [purpose]
+
+## Rules
+
+- [Critical rule 1 — e.g., never commit secrets]
+- [Critical rule 2 — e.g., all public functions need tests]
+- [Critical rule 3 — e.g., use direnv exec for deploy commands]
+```
+
+#### CLAUDE.md Structure
+
+Claude Code loads this file at the start of every session. Keep it concise — under 200 lines.
+
+```markdown
+# [Project Name]
+
+## Quick Reference
+
+- **Language**: [X] with [framework]
+- **Test**: `[test command]`
+- **Build**: `[build command]`
+- **Deploy**: `[deploy command]`
+
+## Coding Standards
+
+[3-5 bullet points on the most important conventions]
+
+## Architecture
+
+[Key patterns, file organisation, data flow — 3-5 bullet points]
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `src/` | Source code |
+| `tests/` | Test files |
+| ... | ... |
+
+## Rules
+
+[Critical do/don't rules that prevent common mistakes]
+```
+
+#### .cursorrules Structure
+
+Cursor rules are plain text, loaded when editing files in the project.
+
+```
+You are working on [project name], a [description].
+
+Language: [X] with [framework]
+Style: [conventions]
+
+Key rules:
+- [Rule 1]
+- [Rule 2]
+- [Rule 3]
+
+When writing code:
+- [Pattern 1]
+- [Pattern 2]
+
+When writing tests:
+- [Test pattern 1]
+- [Test pattern 2]
+
+File structure:
+- src/ — source code
+- tests/ — test files
+```
+
+#### .github/copilot-instructions.md Structure
+
+```markdown
+# Copilot Instructions
+
+## Project Context
+
+This is a [description] built with [language/framework].
+
+## Coding Standards
+
+- [Convention 1]
+- [Convention 2]
+- [Convention 3]
+
+## Patterns to Follow
+
+- [Pattern 1]
+- [Pattern 2]
+
+## Patterns to Avoid
+
+- [Anti-pattern 1]
+- [Anti-pattern 2]
+```
+
+## Staleness Audit
+
+When running in `audit` mode, check existing context files for drift:
+
+1. **Version mismatch** — Does the context file reference the correct language/framework version?
+2. **Missing commands** — Are test/build/deploy commands still accurate? Run them to verify.
+3. **Stale paths** — Do referenced file paths still exist?
+4. **New conventions** — Has the project adopted new patterns (e.g., added ESLint, switched to Vitest) that aren't reflected?
+
+Report format:
+```
+AI Context Audit:
+  ✓ AGENTS.md — up to date (last modified: 2 days ago)
+  ⚠ CLAUDE.md — references jest but vitest.config.ts detected
+  ✗ .cursorrules — references src/index.ts but file moved to src/main.ts
+  · .github/copilot-instructions.md — not present
+```
+
+## Anti-Patterns
+
+- **Don't dump entire codebase** — context files should be concise summaries, not file listings
+- **Don't include secrets** — no API keys, tokens, or credentials in context files
+- **Don't repeat framework docs** — reference framework conventions, don't reproduce them
+- **Don't over-constrain** — provide patterns, not rigid rules that prevent creative problem-solving
+- **Don't include session-specific state** — context files should be durable across sessions

--- a/.claude/skills/api-reference/SKILL.md
+++ b/.claude/skills/api-reference/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: api-reference
+description: Guidance for setting up API reference documentation generators — TypeDoc, Sphinx, godoc, and rustdoc. Detects project language, recommends the right tool, and provides configuration templates. Use when a project needs automated API documentation from source code comments.
+---
+
+# API Reference Generator Guidance
+
+## Philosophy
+
+API reference docs are the **Reference** quadrant of the Diataxis framework — information-oriented, accurate, and complete. They document every public function, class, method, parameter, and return type.
+
+This skill does **not** generate API docs directly — that's the job of language-specific tools (TypeDoc, Sphinx, godoc, rustdoc). Instead, it provides configuration guidance and comment conventions so those tools produce high-quality output.
+
+## Language Detection
+
+Detect the project language to recommend the appropriate tool:
+
+```bash
+# Check for language-specific manifest files
+[ -f "package.json" ] && echo "javascript/typescript"
+[ -f "tsconfig.json" ] && echo "typescript (confirmed)"
+[ -f "pyproject.toml" ] || [ -f "setup.py" ] && echo "python"
+[ -f "go.mod" ] && echo "go"
+[ -f "Cargo.toml" ] && echo "rust"
+```
+
+## TypeScript / JavaScript (TypeDoc)
+
+**Tool:** [TypeDoc](https://typedoc.org/) — generates HTML or Markdown documentation from TypeScript source code and JSDoc comments.
+
+### Installation
+
+```bash
+npm install --save-dev typedoc
+```
+
+### Configuration
+
+Create `typedoc.json` in the project root:
+
+```json
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs/api",
+  "plugin": ["typedoc-plugin-markdown"],
+  "readme": "none",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeInternal": true,
+  "categorizeByGroup": true,
+  "sort": ["source-order"]
+}
+```
+
+For Markdown output (recommended for GitHub-hosted docs):
+```bash
+npm install --save-dev typedoc-plugin-markdown
+```
+
+### TSDoc Comment Conventions
+
+```typescript
+/**
+ * Generates a marketing-friendly README from codebase analysis.
+ *
+ * Scans the project for features, translates them into benefit-driven
+ * language, and outputs a complete README.md following the 4-question
+ * framework.
+ *
+ * @param options - Configuration for README generation
+ * @param options.projectPath - Path to the project root
+ * @param options.format - Output format: 'github' | 'npm' | 'pypi'
+ * @returns The generated README content as a string
+ * @throws {ProjectNotFoundError} If projectPath doesn't exist
+ *
+ * @example
+ * ```typescript
+ * const readme = await generateReadme({
+ *   projectPath: './my-project',
+ *   format: 'github'
+ * })
+ * ```
+ *
+ * @see {@link FeatureExtractor} for the scanning workflow
+ * @since 1.0.0
+ */
+export async function generateReadme(options: ReadmeOptions): Promise<string> {
+```
+
+### package.json Script
+
+```json
+{
+  "scripts": {
+    "docs:api": "typedoc"
+  }
+}
+```
+
+## Python (Sphinx or MkDocs + mkdocstrings)
+
+### Option A: Sphinx + autodoc (traditional, feature-rich)
+
+**Installation:**
+```bash
+pip install sphinx sphinx-autodoc-typehints sphinx-rtd-theme
+```
+
+**Quick setup:**
+```bash
+mkdir docs && cd docs
+sphinx-quickstart --no-sep --project "Project Name" --author "Author"
+```
+
+**conf.py additions:**
+```python
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',  # Google/NumPy-style docstrings
+    'sphinx_autodoc_typehints',
+]
+
+autodoc_member_order = 'bysource'
+autodoc_typehints = 'description'
+```
+
+### Option B: MkDocs + mkdocstrings (modern, Markdown-native)
+
+**Installation:**
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python]
+```
+
+**mkdocs.yml:**
+```yaml
+site_name: Project Name
+theme:
+  name: material
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_source: true
+            show_root_heading: true
+```
+
+### Python Docstring Conventions (Google style)
+
+```python
+def generate_readme(project_path: str, format: str = "github") -> str:
+    """Generate a marketing-friendly README from codebase analysis.
+
+    Scans the project for features, translates them into benefit-driven
+    language, and outputs a complete README.md following the 4-question
+    framework.
+
+    Args:
+        project_path: Path to the project root directory.
+        format: Output format. One of 'github', 'npm', 'pypi'.
+            Defaults to 'github'.
+
+    Returns:
+        The generated README content as a string.
+
+    Raises:
+        ProjectNotFoundError: If project_path doesn't exist.
+        PermissionError: If project_path is not readable.
+
+    Example:
+        >>> readme = generate_readme("./my-project", format="github")
+        >>> print(readme[:50])
+        # My Project
+    """
+```
+
+## Go (godoc)
+
+Go has built-in documentation tooling. No extra packages needed.
+
+### Comment Conventions
+
+```go
+// GenerateReadme produces a marketing-friendly README from codebase analysis.
+//
+// It scans the project at projectPath for features, translates them into
+// benefit-driven language, and returns a complete README following the
+// 4-question framework.
+//
+// The format parameter controls output: "github", "npm", or "pypi".
+//
+// Example:
+//
+//	readme, err := GenerateReadme("./my-project", "github")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println(readme)
+func GenerateReadme(projectPath, format string) (string, error) {
+```
+
+### Running godoc
+
+```bash
+# Local documentation server
+godoc -http=:6060
+
+# Generate static HTML
+go install golang.org/x/pkgsite/cmd/pkgsite@latest
+pkgsite -open .
+```
+
+## Rust (rustdoc)
+
+Rust has built-in documentation via `cargo doc`. No extra packages needed.
+
+### Comment Conventions
+
+```rust
+/// Generates a marketing-friendly README from codebase analysis.
+///
+/// Scans the project for features, translates them into benefit-driven
+/// language, and outputs a complete README following the 4-question
+/// framework.
+///
+/// # Arguments
+///
+/// * `project_path` - Path to the project root directory
+/// * `format` - Output format: `github`, `npm`, or `pypi`
+///
+/// # Returns
+///
+/// The generated README content as a `String`.
+///
+/// # Errors
+///
+/// Returns `ReadmeError::ProjectNotFound` if the path doesn't exist.
+///
+/// # Examples
+///
+/// ```
+/// let readme = generate_readme("./my-project", "github")?;
+/// println!("{}", &readme[..50]);
+/// ```
+pub fn generate_readme(project_path: &str, format: &str) -> Result<String, ReadmeError> {
+```
+
+### Running rustdoc
+
+```bash
+# Generate and open docs
+cargo doc --open --no-deps
+```
+
+## Integration with Docs Hub
+
+Once API reference docs are generated, link them from the docs hub page:
+
+```markdown
+## Reference
+
+- [API Documentation](reference/api.md) — All public functions, types, and interfaces
+- [CLI Reference](reference/cli.md) — All commands, flags, and options
+```
+
+And from the README documentation section:
+
+```markdown
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| ... | ... |
+| [API Reference](docs/reference/api.md) | All public types and functions |
+```
+
+## Anti-Patterns
+
+- **Don't hand-write API docs** — they go stale instantly. Generate from source code comments.
+- **Don't mix API reference with tutorials** — keep them in separate Diataxis quadrants
+- **Don't document private/internal APIs** — only document the public surface area
+- **Don't skip examples** — every non-trivial function should have a usage example in its docstring
+- **Don't use `@inheritdoc` without checking** — inherited docs may not make sense in the subclass context

--- a/.claude/skills/docs-verify/SKILL.md
+++ b/.claude/skills/docs-verify/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: docs-verify
+description: Validates documentation quality and freshness — checks for broken links, stale content, llms.txt sync, image issues, heading hierarchy, and badge URLs. Runs locally or in CI. Use to catch documentation decay before it reaches users.
+---
+
+# Documentation Verifier
+
+## Philosophy
+
+Generating documentation is a solved problem. **Preventing documentation decay** is not. This skill validates that generated docs remain accurate, linked, and fresh over time.
+
+## Verification Checks
+
+### 1. Markdown Lint
+
+Check heading hierarchy and structural consistency across all documentation files.
+
+```bash
+# Find all documentation Markdown files
+find . -name "*.md" -not -path "./.git/*" -not -path "./node_modules/*" | sort
+```
+
+For each file, verify:
+
+- **Heading hierarchy** — H1 > H2 > H3 without skipping levels (no H1 > H3). Critical for RAG chunking and GEO.
+- **Single H1** — Only one H1 per document (the title)
+- **Consistent formatting** — No trailing whitespace, consistent list markers, blank lines around headings
+- **No bare URLs** — Links should use `[text](url)` format, not raw URLs in prose
+
+Report format:
+```
+Markdown Lint:
+  ✓ README.md — 0 issues
+  ⚠ docs/guides/configuration.md:45 — heading level skipped (H2 → H4)
+  ⚠ CONTRIBUTING.md:23 — trailing whitespace
+```
+
+### 2. Link Validation
+
+Check all internal and external links in documentation files.
+
+**Internal links (relative paths and anchors):**
+
+```bash
+# Extract relative links from Markdown files
+grep -roE '\[([^\]]*)\]\(([^)]+)\)' docs/ README.md CONTRIBUTING.md CHANGELOG.md 2>/dev/null
+```
+
+For each relative link:
+- Verify the target file exists on disk
+- Verify anchor links (`#section-name`) match an actual heading in the target file
+- Check for case-sensitivity issues (common on Linux, invisible on macOS)
+
+**External links (URLs):**
+
+For each external URL found in documentation:
+- Check HTTP status code (200 OK, 301 redirect, 404 not found)
+- Timeout after 10 seconds per URL
+- Skip URLs behind authentication (GitHub private repos, paywalled content)
+- Flag any 404s or 5xx errors
+
+Report format:
+```
+Link Validation:
+  Checked: 45 links (32 internal, 13 external)
+  ✓ 42 valid
+  ✗ README.md:89 — docs/guides/migration.md (file not found)
+  ✗ CONTRIBUTING.md:34 — #setup-instructions (anchor not found, did you mean #development-setup?)
+  ⚠ README.md:12 — https://example.com/old-docs (301 redirect → https://example.com/docs)
+```
+
+### 3. llms.txt Sync Check
+
+Verify that `llms.txt` references match actual files on disk.
+
+```bash
+# Extract file paths from llms.txt
+grep -oE '\./[^ ]+\.md' llms.txt 2>/dev/null | while read -r path; do
+  [ -f "$path" ] && echo "✓ $path" || echo "✗ $path (file not found)"
+done
+```
+
+Also check:
+- Every Markdown file in the repo is represented in llms.txt (no orphaned docs)
+- Descriptions in llms.txt match the actual file content (first paragraph check)
+- llms-full.txt (if present) is not stale — compare modification time against source files
+
+Report format:
+```
+llms.txt Sync:
+  ✓ 12/12 referenced files exist
+  ⚠ docs/guides/deployment.md not listed in llms.txt (orphaned doc)
+  ⚠ llms-full.txt is 14 days older than README.md — may need regeneration
+```
+
+### 4. Image Validation
+
+Check that all referenced images exist and are properly formatted.
+
+```bash
+# Extract image references from Markdown files
+grep -roE '!\[([^\]]*)\]\(([^)]+)\)' docs/ README.md 2>/dev/null
+```
+
+For each image reference:
+- **File exists** — Verify the image file is on disk (for relative paths)
+- **Alt text present** — Flag images with empty alt text (`![]()`)
+- **Absolute URLs for registries** — If the project is published to npm/PyPI, images must use absolute URLs (`https://raw.githubusercontent.com/...`), not relative paths
+- **File size** — Flag images over 1MB (GitHub has a 10MB file limit, but large images slow page load)
+
+Report format:
+```
+Image Validation:
+  ✓ docs/images/demo.gif — exists, alt text: "Quick start demo", 2.3MB
+  ⚠ docs/images/architecture.svg — empty alt text
+  ✗ README.md:15 — assets/screenshot.png (file not found)
+  ⚠ README.md:15 — relative image path, will break on npm (use absolute URL)
+```
+
+### 5. Freshness Check
+
+Flag documentation files that haven't been updated recently. Uses `git log` to check the last modification date.
+
+```bash
+# Check last modification date for each doc file
+for f in README.md CONTRIBUTING.md CHANGELOG.md docs/guides/*.md; do
+  if [ -f "$f" ]; then
+    last_modified=$(git log -1 --format="%ci" -- "$f" 2>/dev/null)
+    echo "$f: $last_modified"
+  fi
+done
+```
+
+**Staleness thresholds (configurable):**
+
+| File | Warning | Stale |
+|------|---------|-------|
+| README.md | 90 days | 180 days |
+| CHANGELOG.md | 30 days (if releases exist) | 90 days |
+| CONTRIBUTING.md | 180 days | 365 days |
+| docs/guides/*.md | 90 days | 180 days |
+| SECURITY.md | 180 days | 365 days |
+
+Compare against latest commit date, not calendar date — a dormant project with no commits shouldn't trigger freshness warnings.
+
+Report format:
+```
+Freshness Check:
+  ✓ README.md — updated 12 days ago
+  ⚠ docs/guides/deployment.md — last updated 95 days ago (threshold: 90 days)
+  ✗ CONTRIBUTING.md — last updated 14 months ago (stale)
+  · CHANGELOG.md — 2 releases since last update (v1.3.0, v1.4.0)
+```
+
+### 6. Feature Coverage Sync
+
+Compare features mentioned in README against actual code. Reuses the `feature-benefits` skill's extraction workflow.
+
+1. Load `feature-benefits` skill and run the feature extraction
+2. Parse README.md features section for listed features
+3. Cross-reference:
+   - **Undocumented features** — code evidence exists, but not in README
+   - **Over-documented features** — claimed in README, but no code evidence
+
+Report format:
+```
+Feature Coverage: 8 documented / 10 detected (80%)
+  Missing from README:
+    - WebSocket support — found in src/ws.ts
+    - Rate limiting — found in src/middleware/ratelimit.ts
+  Over-documented:
+    - "AI-powered suggestions" — no code evidence found
+```
+
+### 7. Badge URL Validation
+
+Verify that shields.io badges in README return valid responses.
+
+```bash
+# Extract badge URLs from README
+grep -oE 'https://img\.shields\.io/[^)]+' README.md 2>/dev/null
+```
+
+For each badge URL:
+- Fetch the URL and check for HTTP 200
+- Flag badges that return error SVGs (e.g., "invalid" or "not found")
+- Check that badge links point to valid destinations
+
+Report format:
+```
+Badge Validation:
+  ✓ build status — 200 OK (passing)
+  ✓ npm version — 200 OK (1.4.1)
+  ✗ coverage — 200 OK but shows "unknown" (codecov may not be configured)
+  ⚠ downloads — 301 redirect (badge URL format may be outdated)
+```
+
+## CI-Friendly Output
+
+When run with the `ci` argument, output results in a format suitable for CI/CD pipelines:
+
+- Exit code 0: all checks pass
+- Exit code 1: any check has errors (not warnings)
+- Machine-readable output with file:line format for easy IDE integration
+
+```
+ERROR: README.md:89 — broken link: docs/guides/migration.md (file not found)
+ERROR: llms.txt:5 — sync: ./ROADMAP.md (file not found)
+WARN: docs/guides/deployment.md — stale: last updated 95 days ago
+WARN: README.md:15 — image: relative path will break on npm
+```
+
+## GitHub Actions Workflow Template
+
+For projects that want to run docs verification in CI:
+
+```yaml
+name: docs
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'llms.txt'
+      - 'llms-full.txt'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: '**/*.md'
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --exclude-private --no-progress docs/ README.md CONTRIBUTING.md CHANGELOG.md
+          fail: true
+```
+
+## Anti-Patterns
+
+- **Don't ignore warnings** — a broken link today becomes a confused user tomorrow
+- **Don't run external link checks on every commit** — run them on PRs and weekly schedules to avoid rate limiting
+- **Don't fix docs in a separate PR from code changes** — docs updates should accompany the code that changes behaviour
+- **Don't suppress freshness warnings without reviewing** — stale docs erode trust faster than missing docs

--- a/.claude/skills/launch-artifacts/SKILL.md
+++ b/.claude/skills/launch-artifacts/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: launch-artifacts
+description: Transforms README and CHANGELOG into platform-specific launch content — Dev.to articles, Hacker News posts, Reddit posts, Twitter/X threads, and awesome list submission PRs. Keeps promotion tethered to code artifacts, not generic marketing. Use when launching or announcing a project release.
+---
+
+# Launch Artifacts Generator
+
+## Philosophy
+
+Great documentation is useless if nobody finds it. This skill transforms existing PitchDocs-generated content (README, CHANGELOG, features) into platform-specific posts for launch and promotion.
+
+**Scope boundary:** This skill generates content from existing code artifacts — it does not create generic marketing playbooks. Every artifact traces back to the README, CHANGELOG, or codebase features.
+
+## Prerequisites
+
+Before generating launch artifacts, ensure the project has:
+- A PitchDocs-generated README with hero section and features
+- A CHANGELOG with the release being announced (if applicable)
+- Feature extraction completed via the `feature-benefits` skill
+
+## Platform Templates
+
+### Dev.to Article
+
+Transform README + CHANGELOG into a Dev.to blog post. Dev.to uses Liquid tags for frontmatter.
+
+```markdown
+---
+title: "[Project Name]: [Value proposition from README hero]"
+published: false
+description: "[README explanatory sentence, condensed to 100 chars]"
+tags: [up to 4 relevant tags]
+canonical_url: https://github.com/org/repo
+---
+
+[Opening hook — rewrite the README "Why" section as a narrative problem statement]
+
+## The Problem
+
+[Expand on the problem from the README's "Why" section — use reader-centric language]
+
+## What [Project Name] Does
+
+[Condense the README features into 3-5 key capabilities with code examples]
+
+### [Feature 1]
+
+[Brief explanation with code example from README quickstart]
+
+\`\`\`typescript
+// Copy the most compelling code example from the quickstart
+\`\`\`
+
+### [Feature 2]
+
+[Another key feature with a practical example]
+
+## Getting Started
+
+\`\`\`bash
+[Installation command from README]
+\`\`\`
+
+[Minimal usage example — keep it under 10 lines]
+
+## What's Next
+
+[Link to ROADMAP or upcoming features]
+
+---
+
+*[Project Name] is open source ([licence]) — [link to repo]. Contributions welcome!*
+```
+
+**Dev.to tag selection:**
+- Use existing popular tags (check dev.to/tags)
+- Maximum 4 tags per article
+- Include language tag (`typescript`, `python`), category tag (`opensource`, `devtools`), and 1-2 topic tags
+
+### Hacker News "Show HN" Post
+
+Title + description optimised for Hacker News submission.
+
+**Title format:**
+```
+Show HN: [Project Name] – [One-line value proposition from README hero]
+```
+
+**Rules:**
+- Maximum 80 characters for the title
+- No exclamation marks, no ALL CAPS, no emoji
+- Lead with what it does, not what it is
+- Include the key differentiator
+
+**Description (first comment):**
+```
+Hi HN,
+
+I built [Project Name] to solve [problem from README "Why" section].
+
+[2-3 sentences on the technical approach — what makes this different from alternatives. Include a concrete metric or benchmark if available.]
+
+[1 sentence on the tech stack — language, framework, key dependencies.]
+
+Key features:
+- [Feature 1 — from README features, condensed]
+- [Feature 2]
+- [Feature 3]
+
+[Link to repo] | [Link to docs/demo if available]
+
+Happy to answer questions about [the most technically interesting aspect].
+```
+
+**Timing guidance:**
+- Best days: Tuesday–Thursday
+- Best times: 9:00–11:00 AM US Eastern (14:00–16:00 UTC)
+- Avoid weekends, US holidays, and major tech conference days
+- Source: academic study of 138 repo launches showed +121 stars within 24 hours of HN exposure
+
+### Reddit Post
+
+Formatted for relevant subreddits. Each subreddit has different norms.
+
+**r/programming** (technical audience, link post preferred):
+```
+Title: [Project Name]: [technical description, not marketing]
+URL: https://github.com/org/repo
+```
+
+Add a first comment explaining the motivation:
+```
+Author here. I built this because [problem].
+
+Technical highlights:
+- [Technical detail 1]
+- [Technical detail 2]
+
+Built with [tech stack]. Feedback welcome, especially on [specific area].
+```
+
+**r/webdev** (web developer audience, self-post OK):
+```
+Title: I built [Project Name] to [solve problem] — open source
+Body: [Condensed README with focus on practical usage and DX]
+```
+
+**r/opensource** (open source community):
+```
+Title: [Project Name] — [description] [language/framework]
+Body: [Focus on contribution opportunities, roadmap, and community]
+```
+
+**Reddit rules:**
+- Don't post to more than 2-3 subreddits for the same project
+- Space posts across different subreddits by at least 24 hours
+- Engage genuinely in comments — don't just post and leave
+- Read each subreddit's rules before posting (some ban self-promotion)
+
+### Twitter/X Thread
+
+Convert README features into a 5-tweet thread.
+
+```
+Tweet 1 (hook):
+🚀 Introducing [Project Name]
+
+[One-line value proposition from README hero]
+
+Thread 👇
+
+---
+
+Tweet 2 (problem):
+The problem: [Problem from README "Why" section]
+
+[1-2 sentences expanding on the pain point]
+
+---
+
+Tweet 3 (features):
+What it does:
+
+• [Feature 1] — [benefit]
+• [Feature 2] — [benefit]
+• [Feature 3] — [benefit]
+
+---
+
+Tweet 4 (proof):
+[Concrete metric, benchmark, or social proof]
+
+[Code snippet or screenshot if applicable]
+
+---
+
+Tweet 5 (CTA):
+Try it now:
+
+[install command]
+
+GitHub: [repo URL]
+Docs: [docs URL]
+
+Star ⭐ if you find it useful — it helps others discover it too.
+```
+
+**Twitter/X rules:**
+- 280 characters per tweet
+- Use line breaks for readability
+- Include a code snippet image or screenshot in tweet 3 or 4
+- Thread should be self-contained — each tweet makes sense alone
+
+### Awesome List Submission PR
+
+Template for submitting the project to relevant awesome lists.
+
+**Step 1: Find relevant awesome lists**
+
+```bash
+# Search GitHub for awesome lists in your category
+gh search repos "awesome-[category]" --sort stars --limit 10
+```
+
+**Step 2: Check contribution guidelines**
+
+Every awesome list has its own rules. Before submitting:
+- Read the list's CONTRIBUTING.md or PULL_REQUEST_TEMPLATE.md
+- Check the format of existing entries (description length, link style)
+- Verify the project meets the list's quality criteria (stars, maintenance, docs)
+
+**Step 3: PR body template**
+
+```markdown
+## Add [Project Name]
+
+**Description:** [One-line description matching the list's existing entry format]
+
+**Link:** https://github.com/org/repo
+
+**Why it belongs:** [1-2 sentences on why this project fits the list's criteria]
+
+**Checklist:**
+- [ ] Read the contribution guidelines
+- [ ] Project is actively maintained
+- [ ] Project has documentation
+- [ ] Entry format matches existing entries
+```
+
+**Awesome list entry format** (adapt to match the specific list):
+```markdown
+- [Project Name](https://github.com/org/repo) — One-line description matching the list's style.
+```
+
+### GitHub Discussions Announcement
+
+For projects using GitHub Discussions, template for a release announcement.
+
+```markdown
+Title: [Project Name] v[X.Y.Z] released — [headline feature]
+
+## What's New
+
+[Condense CHANGELOG entries into 3-5 user-facing highlights]
+
+### [Highlight 1]
+
+[1-2 sentences with a code example if applicable]
+
+### [Highlight 2]
+
+[1-2 sentences]
+
+## Upgrade
+
+\`\`\`bash
+[upgrade command]
+\`\`\`
+
+[Link to migration guide if breaking changes]
+
+## What's Next
+
+[Link to ROADMAP or mention upcoming features]
+
+---
+
+Full changelog: [link to CHANGELOG.md or GitHub release]
+```
+
+## Social Preview Image Guidance
+
+GitHub uses the repository's social preview image when links are shared on Twitter/X, Slack, Discord, and LinkedIn.
+
+**Specifications:**
+- **Size:** 1280 x 640 pixels (2:1 ratio)
+- **File size:** Under 1MB, ideally <300KB
+- **Format:** PNG or JPEG
+- **Set via:** Repository Settings > Social preview (manual upload)
+
+**Design recommendations:**
+- Project name in large, readable text (survives thumbnail cropping)
+- One-line value proposition below the name
+- Key visual element — logo, icon, or illustrative graphic
+- Keep critical content centred (platforms crop differently)
+- Use project brand colours for recognition
+
+**Tools for creation:**
+- [Canva](https://canva.com/) — Templates for GitHub social cards
+- [Figma](https://figma.com/) — Custom designs with precise dimensions
+- [og-image generators](https://github.com/vercel/og-image) — Programmatic generation
+
+## Anti-Patterns
+
+- **Don't spam multiple platforms simultaneously** — space posts across 2-3 days
+- **Don't use identical content across platforms** — adapt tone and format for each audience
+- **Don't make claims not backed by the README** — every feature mentioned must trace to code evidence
+- **Don't post and disappear** — engage with comments and questions on every platform
+- **Don't buy stars or upvotes** — artificial engagement is detectable and erodes trust
+- **Don't submit to awesome lists before your docs are ready** — list maintainers check quality

--- a/.claude/skills/pitchdocs-suite/SKILL.md
+++ b/.claude/skills/pitchdocs-suite/SKILL.md
@@ -28,6 +28,8 @@ A well-documented public repository should have these files:
 | `SUPPORT.md` | Where to get help — issues, discussions, external channels | This skill |
 | `.github/release.yml` | Auto-generated release note categories | This skill |
 | `llms.txt` | LLM-friendly content index for AI tools (Cursor, Windsurf, Claude Code) | `llms-txt` skill |
+| `AGENTS.md` | Cross-tool AI agent context — conventions, architecture, key commands | `ai-context` skill |
+| `.github/copilot-instructions.md` | GitHub Copilot repository-level instructions | `ai-context` skill |
 | `CODE_OF_CONDUCT.md` | Community behaviour standards | This skill |
 | `SECURITY.md` | Vulnerability reporting process | This skill |
 | `.github/ISSUE_TEMPLATE/config.yml` | Issue template chooser config | This skill |
@@ -40,6 +42,8 @@ A well-documented public repository should have these files:
 | File | Purpose | Generator |
 |------|---------|-----------|
 | `ROADMAP.md` | Public development roadmap | `roadmap` skill |
+| `CLAUDE.md` | Project-specific Claude Code context — coding standards, architecture, key paths | `ai-context` skill |
+| `.cursorrules` | Cursor-specific rules derived from codebase conventions | `ai-context` skill |
 | `docs/guides/configuration.md` | All config options explained | `user-guides` skill |
 | `docs/guides/deployment.md` | Production deployment guide | `user-guides` skill |
 | `docs/guides/troubleshooting.md` | Common issues and solutions | `user-guides` skill |
@@ -170,12 +174,12 @@ Guidance on storing and referencing visual elements (screenshots, demo GIFs, dia
 
 ```bash
 # Check for all expected files
-for f in README.md LICENSE CONTRIBUTING.md CHANGELOG.md ROADMAP.md CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md llms.txt; do
+for f in README.md LICENSE CONTRIBUTING.md CHANGELOG.md ROADMAP.md CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md llms.txt AGENTS.md CLAUDE.md .cursorrules; do
   [ -f "$f" ] && echo "✓ $f" || echo "✗ $f (missing)"
 done
 
-# Check .github templates
-for f in .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE/config.yml; do
+# Check .github templates and AI context files
+for f in .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE/config.yml .github/copilot-instructions.md; do
   [ -f "$f" ] && echo "✓ $f" || echo "✗ $f (missing)"
 done
 

--- a/.claude/skills/public-readme/SKILL.md
+++ b/.claude/skills/public-readme/SKILL.md
@@ -40,6 +40,16 @@ npm install project-name
 | Feature A | Saves 30 min per release | :white_check_mark: Stable |
 ```
 
+### GEO: Optimising for AI Citation
+
+Follow the GEO section in the `doc-standards` rule. These README-specific additions ensure the README surfaces correctly in AI-generated answers:
+
+1. **First paragraph as standalone definition** — The bold one-liner in the hero must work as a standalone definition if extracted with no surrounding context. LLMs quote top-of-page definitions when answering "what is X?" queries.
+2. **Comparison section** — Include a "How It Compares" section (section 6 below) with a feature comparison table. LLMs surface these when answering "X vs Y" and "best X for Y" queries.
+3. **Statistics and benchmarks** — Where evidence exists, include a benchmarks section or embed concrete numbers in feature descriptions. Content with statistics gets up to 28% more AI visibility.
+4. **Semantic heading hierarchy** — Strict H1 > H2 > H3 without skipping levels. Descriptive headings containing topic keywords improve RAG chunking accuracy.
+5. **Atomic feature descriptions** — Each feature bullet or table row should be comprehensible without reading the surrounding context. AI extractors often pull individual items, not entire sections.
+
 ### 1. Hero Section
 
 ```markdown

--- a/.claude/skills/user-guides/SKILL.md
+++ b/.claude/skills/user-guides/SKILL.md
@@ -11,19 +11,55 @@ User guides answer the question: **"How do I do [specific thing]?"**
 
 They complement the README (which sells and introduces) by providing detailed, task-oriented instructions for users who are already onboard.
 
+## Diataxis Framework
+
+All documentation should be classified into one of four quadrants from the [Diataxis framework](https://diataxis.fr/). Each quadrant serves a different reader need:
+
+| Quadrant | Purpose | Reader State | Directory |
+|----------|---------|-------------|-----------|
+| **Tutorials** | Learning-oriented lessons | "I want to learn" | `docs/tutorials/` |
+| **How-to Guides** | Task-oriented recipes | "I want to do X" | `docs/guides/` |
+| **Reference** | Information-oriented lookup | "I need to check Y" | `docs/reference/` or `docs/api/` |
+| **Explanation** | Understanding-oriented context | "I want to understand why" | `docs/explanation/` |
+
+**Rules:**
+- Classify every document into exactly one quadrant before writing — don't mix tutorial prose with reference tables
+- Tutorials walk through a complete learning journey; guides solve a specific task. A tutorial says "let's build a blog"; a guide says "how to add pagination"
+- Reference docs are dry, accurate, and complete — every parameter, every option, every return type. No narrative.
+- Explanation docs cover architecture decisions, design philosophy, and "why it works this way" — they complement reference without duplicating it
+- Not every project needs all four quadrants. At minimum, provide **How-to Guides** (this skill's primary output) and link to any existing reference docs.
+
+### Classifying Existing Docs
+
+During the guide discovery workflow (Step 1), classify each existing and needed document:
+
+```
+Tutorials:     docs/tutorials/build-your-first-app.md
+How-to Guides: docs/guides/getting-started.md, docs/guides/configuration.md
+Reference:     docs/reference/api.md, docs/reference/cli.md
+Explanation:   docs/explanation/architecture.md, docs/explanation/security-model.md
+```
+
+Flag any quadrant with zero documents — this indicates a documentation gap worth addressing.
+
 ## Guide Structure
 
 ### Directory Layout
 
 ```
 docs/
-├── guides/
+├── tutorials/                  # Learning-oriented lessons (Diataxis: Tutorial)
+│   └── build-your-first-app.md
+├── guides/                     # Task-oriented how-to recipes (Diataxis: How-to)
 │   ├── getting-started.md      # First-time setup, expanded quickstart
 │   ├── configuration.md        # All config options explained
 │   ├── [task-name].md          # One guide per common task
 │   └── troubleshooting.md      # Common problems and solutions
-├── api/                        # API reference (if applicable)
-│   └── README.md
+├── reference/                  # Information-oriented lookup (Diataxis: Reference)
+│   ├── api.md                  # API reference
+│   └── cli.md                  # CLI reference
+├── explanation/                # Understanding-oriented context (Diataxis: Explanation)
+│   └── architecture.md         # Design decisions and architecture
 └── README.md                   # Docs index / hub page
 ```
 
@@ -249,16 +285,112 @@ npx package-name
 - **Task-oriented**: "How to deploy to production" not "Deployment documentation"
 - **Numbered steps**: Every guide is a numbered sequence
 - **Expected output**: Show what success looks like after each step
-- **Error recovery**: Mention common mistakes and how to fix them
-- **Cross-links**: Every guide links to related guides and back to the hub
+- **Error recovery**: After each step, show common failure modes and how to fix them
+- **Cross-links**: Every guide links to related guides, Diataxis siblings, and back to the hub
 - **Active voice**: "Run the command" not "The command should be run"
 - **Consistent spelling**: follow the project's existing language conventions
+- **Copy-paste-ready code**: Every code block must be runnable as-is — no `...` placeholders, no incomplete snippets, no "replace with your value" without showing the exact replacement
+
+### Copy-Paste-Ready Code Examples
+
+Every code block in a guide must be directly executable:
+
+```markdown
+### 2. Configure the database
+
+Create a `wrangler.toml` configuration file:
+
+\`\`\`toml
+name = "my-api"
+compatibility_date = "2024-01-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "your-database-id"
+\`\`\`
+
+**Note:** Replace `your-database-id` with the ID from step 1. You can find it by running `wrangler d1 list`.
+```
+
+**Rules:**
+- Include import statements — don't assume readers know the package name
+- Show expected output after every command
+- Use realistic values (not `foo`, `bar`, `test123`) — readers copy-paste and expect real patterns
+- If a value must be customised, call it out explicitly after the code block
+
+### Error Recovery Patterns
+
+After each major step, include a collapsible troubleshooting section for common failures:
+
+```markdown
+### 3. Start the development server
+
+\`\`\`bash
+npm run dev
+\`\`\`
+
+You should see:
+\`\`\`
+Server running at http://localhost:3000
+\`\`\`
+
+<details>
+<summary><strong>Troubleshooting: Port already in use</strong></summary>
+
+If you see `Error: listen EADDRINUSE :::3000`:
+
+\`\`\`bash
+# Find and kill the process using port 3000
+lsof -ti:3000 | xargs kill -9
+npm run dev
+\`\`\`
+
+</details>
+```
+
+Use `<details>` for error recovery so it doesn't clutter the happy path. For GitHub-only guides, this collapses neatly; for cross-renderer guides, use a bold inline callout instead.
+
+### Video and Screencast Placeholders
+
+When a guide involves CLI interaction or multi-step UI workflows, suggest terminal recording placement:
+
+```markdown
+### Demo
+
+<!-- Terminal recording: Run `asciinema rec` before starting, `asciinema upload` when done -->
+<!-- Suggested recording: Steps 1-3 (install, configure, verify) in a single session -->
+<!-- Alternative: Record a 30-second GIF with `terminalizer` or `vhs` -->
+
+Watch the [terminal recording](link) to see the full setup flow.
+```
+
+**When to suggest recordings:**
+- Getting started guides (always)
+- Guides with 5+ CLI steps
+- Guides involving interactive prompts or TUI interfaces
+- Migration guides where the before/after is instructive
+
+### Diataxis Cross-Links
+
+Each guide must link to related documents in other Diataxis quadrants:
+
+```markdown
+## What's Next?
+
+- **Tutorial**: [Build Your First App](../tutorials/build-first-app.md) — hands-on lesson that builds on this setup
+- **Reference**: [CLI Reference](../reference/cli.md) — all flags and options for commands used in this guide
+- **Explanation**: [Architecture Overview](../explanation/architecture.md) — understand why the project is structured this way
+- [Back to Docs Hub](../README.md)
+```
 
 ## Anti-Patterns
 
-- **Don't dump API reference into guides** — guides are task-oriented, API docs are reference
+- **Don't dump API reference into guides** — guides are task-oriented, API docs are reference (use Diataxis separation)
 - **Don't assume knowledge** — link to prerequisites
 - **Don't skip verification steps** — users need to know they succeeded
 - **Don't write walls of text** — use code blocks, tables, and short paragraphs
 - **Don't orphan guides** — every guide must be linked from README or docs hub
-- **Don't mix guide and reference** — keep them in separate directories
+- **Don't mix guide and reference** — keep them in separate Diataxis quadrants
+- **Don't use placeholder code** — every code block must be copy-paste-ready with realistic values
+- **Don't bury prerequisites in prose** — use a structured prerequisites block (see `doc-standards` GEO section)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PitchDocs
 
-Generate high-quality public-facing repository documentation with a marketing edge. PitchDocs creates READMEs that sell, changelogs that communicate value, roadmaps from GitHub milestones, and audits your docs completeness.
+Generate high-quality public-facing repository documentation with a marketing edge. PitchDocs creates READMEs that sell, changelogs that communicate value, roadmaps from GitHub milestones, AI context files for coding assistants, and audits your docs completeness — with GEO-optimised structure for AI citation and launch artifacts for promotion.
 
 ## Documentation Standards
 
@@ -29,10 +29,14 @@ Skills are loaded on-demand to provide deep reference knowledge. Each lives at `
 | `feature-benefits` | 5-step codebase scanning workflow across 10 signal categories. Extracts concrete features with file/function evidence and translates them into benefits across 5 categories (time saved, confidence gained, pain avoided, capability unlocked, cost reduced) |
 | `changelog` | Keep a Changelog format with language rules that rewrite conventional commits into user-facing benefit language. Maps `feat:` to Added, `fix:` to Fixed, etc. |
 | `roadmap` | Roadmap structure from GitHub milestones with emoji status indicators, mission statement, and community involvement section |
-| `pitchdocs-suite` | Full 17+ file inventory (README, CONTRIBUTING, CHANGELOG, CODE_OF_CONDUCT, SECURITY, issue templates, PR templates, and more), GitHub metadata guidance, visual assets, licence selection framework, and ready-to-use templates |
+| `pitchdocs-suite` | Full 20+ file inventory (README, CONTRIBUTING, CHANGELOG, CODE_OF_CONDUCT, SECURITY, AI context files, issue templates, PR templates, and more), GitHub metadata guidance, visual assets, licence selection framework, and ready-to-use templates |
 | `llms-txt` | llmstxt.org specification reference for generating `llms.txt` and `llms-full.txt` — LLM-friendly content indices for AI coding assistants |
 | `package-registry` | npm and PyPI metadata field auditing, cross-renderer README compatibility (GitHub vs npm vs PyPI), trusted publishing guidance, and registry-specific badges |
-| `user-guides` | Task-oriented how-to documentation structure with numbered steps, prerequisites, verification, and cross-linked hub pages |
+| `user-guides` | Task-oriented how-to documentation with Diataxis framework, numbered steps, copy-paste-ready code, error recovery, and cross-linked hub pages |
+| `ai-context` | AI IDE context file generation — AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md from codebase analysis with staleness audit |
+| `docs-verify` | Documentation validation — broken links, stale content, llms.txt sync, heading hierarchy, badge URLs, and CI-friendly output |
+| `launch-artifacts` | Platform-specific launch content — Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions |
+| `api-reference` | API reference generator guidance — TypeDoc, Sphinx, godoc, rustdoc configuration templates and comment conventions |
 
 ## Docs-Writer Agent
 
@@ -53,6 +57,9 @@ These commands are defined in `commands/*.md` and can be invoked as slash comman
 | `features` | Extract features from code and translate to benefits |
 | `changelog` | Generate CHANGELOG.md from git history with user-benefit language |
 | `roadmap` | Generate ROADMAP.md from GitHub milestones and issues |
-| `docs-audit` | Audit docs completeness, quality, GitHub metadata, and registry config |
+| `docs-audit` | Audit docs completeness, quality, GitHub metadata, AI context files, Diataxis coverage, and registry config |
 | `llms-txt` | Generate llms.txt and llms-full.txt for AI discoverability |
-| `user-guide` | Generate task-oriented user guides in `docs/guides/` |
+| `user-guide` | Generate task-oriented user guides in `docs/guides/` with Diataxis classification |
+| `ai-context` | Generate AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md from codebase analysis |
+| `docs-verify` | Verify links, freshness, llms.txt sync, heading hierarchy, and badge URLs |
+| `launch` | Generate Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0](https://github.com/littlebearapps/pitchdocs/compare/v1.4.1...v1.5.0) (2026-02-26)
+
+### Added
+
+- **GEO (Generative Engine Optimisation)** — new section in `doc-standards` rule with crisp definitions, atomic sections, concrete statistics, comparison tables, TL;DR blocks, and cross-referencing patterns structured for LLM citation
+- **GEO patterns in `public-readme` skill** — first-paragraph-as-definition guidance, comparison table optimisation for "X vs Y" queries, and semantic heading hierarchy enforcement
+- **Diataxis framework** in `user-guides` skill — classify docs into tutorials, how-to guides, reference, and explanation quadrants with updated directory layout
+- **`ai-context` skill and `/ai-context` command** — generate AGENTS.md, CLAUDE.md, .cursorrules, and .github/copilot-instructions.md from codebase analysis with staleness audit mode
+- **`docs-verify` skill and `/docs-verify` command** — validate broken links, stale content (90-day threshold via git blame), llms.txt sync, heading hierarchy, image alt text, badge URLs, and feature coverage with CI-friendly output
+- **`launch-artifacts` skill and `/launch` command** — transform README/CHANGELOG into Dev.to articles, Hacker News "Show HN" posts, Reddit posts, Twitter/X threads, awesome list submission PRs, and social preview image guidance
+- **`api-reference` skill** — configuration templates and comment conventions for TypeDoc, Sphinx/mkdocstrings, godoc, and rustdoc with language auto-detection
+- **AI context files in `pitchdocs-suite` inventory** — AGENTS.md and copilot-instructions.md at Tier 2, CLAUDE.md and .cursorrules at Tier 3
+- **Diataxis coverage check in `/docs-audit`** — flags missing documentation quadrants
+- **AI context staleness check in `/docs-audit`** — verifies context files match current codebase
+- **Documentation verification check in `/docs-audit`** — recommends `/docs-verify` for comprehensive validation
+- **Enhanced user guide patterns** — copy-paste-ready code examples, error recovery with collapsible troubleshooting, video/screencast placement guidance, and Diataxis cross-links
+- **GitHub Actions docs CI template** — markdownlint + lychee link checking workflow in `docs-verify` skill
+
+### Changed
+
+- `pitchdocs-suite` audit scan now checks for AGENTS.md, CLAUDE.md, .cursorrules, and copilot-instructions.md
+- `docs-writer` agent now references 4 additional skills (ai-context, docs-verify, launch-artifacts, api-reference)
+- Docs inventory expanded from 17+ to 20+ files across all tiers
+- Plugin version bumped to 1.5.0 with new keywords (seo, geo, ai-context, agents-md, diataxis)
+
 ## [1.4.1](https://github.com/littlebearapps/pitchdocs/compare/v1.4.0...v1.4.1) (2026-02-26)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,19 @@ pitchdocs/
 │   ├── agents/docs-writer.md      # Long-form doc generation agent
 │   ├── rules/doc-standards.md     # Tone, language, and quality standards
 │   └── skills/                    # Reference knowledge (loaded on-demand)
+│       ├── ai-context/SKILL.md
+│       ├── api-reference/SKILL.md
 │       ├── changelog/SKILL.md
+│       ├── docs-verify/SKILL.md
 │       ├── feature-benefits/SKILL.md
+│       ├── launch-artifacts/SKILL.md
 │       ├── llms-txt/SKILL.md
 │       ├── package-registry/SKILL.md
 │       ├── pitchdocs-suite/SKILL.md
 │       ├── public-readme/SKILL.md
 │       ├── roadmap/SKILL.md
 │       └── user-guides/SKILL.md
-├── commands/                      # Slash commands (/readme, /changelog, etc.)
+├── commands/                      # Slash commands (/readme, /changelog, /ai-context, etc.)
 └── upstream-versions.json         # Pinned upstream spec versions
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Give your AI the knowledge to map out any codebase, extract a features-and-benef
 
 A plugin for [Claude Code](https://code.claude.com/) and [OpenCode](https://opencode.ai/) — also works with [Codex CLI](https://codex.openai.com/), [Cursor](https://cursor.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and more.
 
-[![Version](https://img.shields.io/static/v1?label=version&message=1.4.1&color=blue)](CHANGELOG.md) <!-- x-release-please-version -->
+[![Version](https://img.shields.io/static/v1?label=version&message=1.5.0&color=blue)](CHANGELOG.md) <!-- x-release-please-version -->
 [![License](https://img.shields.io/github/license/littlebearapps/pitchdocs)](LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Plugin-D97757?logo=claude&logoColor=white)](https://code.claude.com/docs/en/plugins)
 [![OpenCode Compatible](https://img.shields.io/badge/OpenCode-Compatible-22c55e)](https://opencode.ai/)
@@ -53,15 +53,18 @@ PitchDocs scans your codebase, extracts features with file-level evidence, trans
 
 Beyond the README, a professional open-source repo needs **CHANGELOG**, **CONTRIBUTING**, **ROADMAP**, **CODE_OF_CONDUCT**, **SECURITY**, issue templates, PR templates, release config, and more. Writing all of these by hand is tedious and error-prone.
 
-Run `/docs-audit fix` to scan your repo against a 17+ file checklist and auto-generate everything that's missing — or use individual commands (`/changelog`, `/roadmap`, `/user-guide`) for just the docs you need.
+Run `/docs-audit fix` to scan your repo against a 20+ file checklist and auto-generate everything that's missing — or use individual commands (`/changelog`, `/roadmap`, `/user-guide`) for just the docs you need.
 
 ### Make your project discoverable
 
 Great docs are useless if nobody can find them. PitchDocs handles the discovery layer:
 
 - **`llms.txt`** — generate AI-readable content indices following the [llmstxt.org](https://llmstxt.org/) spec, so AI coding assistants and search engines surface your docs (SEO and GEO)
+- **AI context files** — generate AGENTS.md, CLAUDE.md, .cursorrules, and copilot-instructions.md so AI coding assistants understand your project's conventions and architecture
+- **GEO-optimised structure** — crisp definitions, atomic sections, comparison tables, and concrete statistics structured for LLM extraction and citation
 - **npm / PyPI metadata** — audit your `package.json` and `pyproject.toml` for missing fields that affect your registry page (description, keywords, repository, homepage, types)
 - **Cross-renderer compatibility** — ensure your README renders correctly on GitHub, npm, and PyPI, not just one platform
+- **Launch artifacts** — transform your README and CHANGELOG into Dev.to articles, Hacker News posts, Reddit posts, and awesome list submissions
 - **Upstream spec drift detection** — a GitHub Action checks monthly that your CHANGELOG, CODE_OF_CONDUCT, and commit conventions follow the latest spec versions
 
 ---
@@ -81,17 +84,24 @@ PitchDocs generates documentation with a **marketing edge** — docs that answer
 
 Every doc follows **progressive disclosure** — non-technical first paragraph, technical details deeper — and every doc **cross-links** to related docs so readers never hit a dead end.
 
+Beyond human readers, PitchDocs also optimises for **AI discoverability**. Docs are structured with crisp definitions, atomic sections, comparison tables, and concrete statistics so that ChatGPT, Perplexity, Google AI Overviews, and other generative engines can extract and cite your project accurately. AI context files (AGENTS.md, CLAUDE.md, .cursorrules) ensure coding assistants understand your conventions from day one — and launch artifacts help you reach the third-party platforms (Dev.to, Hacker News, Reddit, awesome lists) that AI systems treat as trust signals.
+
 ---
 
 ## 🎯 Features
 
 - **Evidence-based feature extraction** — scans 10 signal categories in your codebase and surfaces selling points automatically, with every feature traced to actual code
 - **4-question framework on every doc** — validates that your docs answer "Does this solve my problem?", "Can I use it?", "Who made it?", and "Where do I learn more?"
-- **17+ file documentation audit** — never ship a repo with missing docs, broken metadata, or invisible image links
-- **7 slash commands** — generate any doc type from your terminal in under a minute, from README to llms.txt
+- **GEO-optimised content structure** — crisp definitions, atomic sections, comparison tables, and concrete statistics structured for LLM extraction and AI citation (based on the Princeton GEO study)
+- **AI context file generation** — generate AGENTS.md, CLAUDE.md, .cursorrules, and copilot-instructions.md from a single codebase scan so AI coding assistants understand your conventions
+- **Diataxis documentation framework** — classify docs into tutorials, how-to guides, reference, and explanation quadrants for clear information architecture
+- **Documentation verification** — check for broken links, stale content, llms.txt sync, heading hierarchy issues, and badge URL validity — locally or in CI
+- **Launch artifacts** — transform your README and CHANGELOG into Dev.to articles, Hacker News "Show HN" posts, Reddit posts, Twitter/X threads, and awesome list submission PRs
+- **20+ file documentation audit** — never ship a repo with missing docs, broken metadata, AI context drift, or invisible image links
+- **10 slash commands** — generate any doc type from your terminal in under a minute, from README to launch artifacts
 - **Ready-to-use templates** — CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, SUPPORT, issue templates, PR templates, and release config — one plugin replaces writing 10+ files by hand
 - **llms.txt generation** — create AI-readable content indices following the [llmstxt.org](https://llmstxt.org/) spec so coding assistants and search engines surface your docs
-- **Licence selection and visual assets** — choose the right licence and present your project with compelling visuals
+- **API reference guidance** — configuration templates for TypeDoc, Sphinx, godoc, and rustdoc with comment conventions for each language
 - **npm and PyPI compatibility** — audit registry metadata and ensure your README renders correctly on GitHub, npm, and PyPI
 - **Progressive disclosure** — docs open with non-technical language and reveal technical depth as readers scroll, with automatic cross-linking between sections
 - **Upstream spec drift detection** — a GitHub Action checks monthly that your CHANGELOG, CODE_OF_CONDUCT, and commit conventions follow the latest spec versions
@@ -106,9 +116,12 @@ Every doc follows **progressive disclosure** — non-technical first paragraph, 
 | `/features` | Extract features from code and translate to benefits — output as inventory, table, or bold+em-dash bullets | Never miss a feature worth documenting |
 | `/changelog` | Generate CHANGELOG.md from git history with user-benefit language | Users see what changed for *them*, not your commit log |
 | `/roadmap` | Generate ROADMAP.md from GitHub milestones and issues | Show contributors where the project is heading |
-| `/docs-audit` | Audit docs completeness, quality, GitHub metadata, visual assets, and npm/PyPI registry config | Catch gaps in files, metadata, images, and package registry fields before you ship |
+| `/docs-audit` | Audit docs completeness, quality, GitHub metadata, visual assets, AI context files, Diataxis coverage, and npm/PyPI registry config | Catch gaps in files, metadata, images, and package registry fields before you ship |
 | `/llms-txt` | Generate llms.txt and llms-full.txt for AI discoverability | AI coding assistants and search engines find and understand your docs |
-| `/user-guide` | Generate task-oriented user guides in `docs/guides/` | Readers find answers without reading your source code |
+| `/user-guide` | Generate task-oriented user guides in `docs/guides/` with Diataxis classification | Readers find answers without reading your source code |
+| `/ai-context` | Generate AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md from codebase analysis | AI coding assistants understand your project's conventions from day one |
+| `/docs-verify` | Verify links, freshness, llms.txt sync, heading hierarchy, and badge URLs | Catch documentation decay before it reaches users |
+| `/launch` | Generate Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions | Transform docs into platform-specific launch content |
 
 The **docs-writer** agent powers these commands — it scans your codebase, extracts features with evidence, and writes docs that pass the 4-question test.
 
@@ -141,6 +154,21 @@ The **docs-writer** agent powers these commands — it scans your codebase, extr
 
 # Generate a getting-started user guide
 /user-guide getting-started
+
+# Generate AI context files for all supported tools
+/ai-context
+
+# Generate CLAUDE.md only
+/ai-context claude
+
+# Verify all docs for broken links and stale content
+/docs-verify
+
+# Generate launch artifacts for all platforms
+/launch
+
+# Generate a Dev.to article from your README
+/launch devto
 ```
 
 ---
@@ -151,14 +179,18 @@ Skills are loaded on-demand to provide deep reference knowledge:
 
 | Skill | What You Get |
 |-------|-------------|
-| `public-readme` | README structure with three-part hero, use-case framing, bold+em-dash features, and the Daytona/Banesullivan marketing framework |
+| `public-readme` | README structure with three-part hero, use-case framing, bold+em-dash features, GEO patterns, and the Daytona/Banesullivan marketing framework |
 | `feature-benefits` | 5-step codebase scanning workflow across 10 signal categories with evidence-based benefit translation — outputs as inventory, table, or bold+em-dash bullets |
 | `changelog` | Keep a Changelog format with language rules that rewrite commits into user-facing benefit language |
 | `roadmap` | Roadmap structure from GitHub milestones with emoji status indicators and community involvement section |
-| `pitchdocs-suite` | 17+ file inventory, GitHub metadata, visual assets guidance, licence selection framework, and ready-to-use templates |
+| `pitchdocs-suite` | 20+ file inventory, GitHub metadata, AI context files, visual assets guidance, licence selection framework, and ready-to-use templates |
 | `llms-txt` | llmstxt.org specification reference with generation patterns for repos and docs sites |
 | `package-registry` | npm and PyPI metadata field inventories, README cross-renderer compatibility, trusted publishing guidance, and registry badges |
-| `user-guides` | Task-oriented how-to documentation with numbered steps, verification, and cross-linked hub pages |
+| `user-guides` | Task-oriented how-to documentation with Diataxis framework, numbered steps, copy-paste-ready code, error recovery, and cross-linked hub pages |
+| `ai-context` | AI IDE context file generation — AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md from codebase analysis |
+| `docs-verify` | Documentation validation — broken links, stale content, llms.txt sync, heading hierarchy, badge URLs, and CI-friendly output |
+| `launch-artifacts` | Platform-specific launch content — Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions |
+| `api-reference` | API reference generator guidance — TypeDoc, Sphinx, godoc, rustdoc configuration templates and comment conventions |
 
 ---
 
@@ -170,16 +202,16 @@ The source of truth lives in `.claude/`. Here's what's inside and what each piec
 
 | Directory | Contents | Purpose |
 |-----------|----------|---------|
-| `.claude/skills/*/SKILL.md` | 8 skill files | Reference knowledge for README generation, feature extraction, changelogs, roadmaps, user guides, llms.txt, package registry auditing, and full docs suite inventory |
+| `.claude/skills/*/SKILL.md` | 12 skill files | Reference knowledge for README generation, feature extraction, changelogs, roadmaps, user guides, llms.txt, package registry auditing, AI context files, docs verification, launch artifacts, API reference, and full docs suite inventory |
 | `.claude/agents/docs-writer.md` | 1 agent file | Orchestration workflow: codebase scanning → feature extraction → doc writing → validation |
-| `.claude/rules/doc-standards.md` | 1 rule file | Quality standards: 4-question framework, progressive disclosure, benefit-driven language, feature list formatting (bold+em-dash and table), three-part hero structure, visual formatting with emoji anchors |
-| `commands/*.md` | 7 command files | Slash command definitions for `/readme`, `/changelog`, `/roadmap`, `/docs-audit`, `/features`, `/llms-txt`, `/user-guide` |
+| `.claude/rules/doc-standards.md` | 1 rule file | Quality standards: 4-question framework, GEO optimisation, progressive disclosure, benefit-driven language, feature list formatting (bold+em-dash and table), three-part hero structure, visual formatting with emoji anchors |
+| `commands/*.md` | 10 command files | Slash command definitions for `/readme`, `/changelog`, `/roadmap`, `/docs-audit`, `/features`, `/llms-txt`, `/user-guide`, `/ai-context`, `/docs-verify`, `/launch` |
 
 ### OpenCode
 
 [OpenCode](https://opencode.ai/) reads `.claude/skills/` natively — PitchDocs works out of the box with no extra setup.
 
-**Install** the same way as Claude Code (clone or add as a plugin), then invoke skills by name in your OpenCode session. The 8 SKILL.md files, the docs-writer agent, and the doc-standards rule are all picked up automatically.
+**Install** the same way as Claude Code (clone or add as a plugin), then invoke skills by name in your OpenCode session. The 12 SKILL.md files, the docs-writer agent, and the doc-standards rule are all picked up automatically.
 
 OpenCode also supports MCP servers, so if you have the GitHub MCP server configured, the docs-writer agent can access repository metadata, issues, and releases just as it does in Claude Code.
 
@@ -193,7 +225,7 @@ OpenCode also supports MCP servers, so if you have the GitHub MCP server configu
 # From your project root (not the PitchDocs repo)
 PITCHDOCS="/path/to/pitchdocs"
 
-# Copy all 8 skills
+# Copy all 12 skills
 cp -r "$PITCHDOCS/.claude/skills/"* .agents/skills/
 
 # Copy the quality standards as AGENTS.md (Codex reads this automatically)

--- a/commands/ai-context.md
+++ b/commands/ai-context.md
@@ -1,0 +1,52 @@
+---
+description: "Generate AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md): $ARGUMENTS"
+argument-hint: "[claude|agents|cursor|copilot|audit] or no args for all"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Write
+  - Edit
+---
+
+# /ai-context
+
+Generate context files that help AI coding assistants understand your project's conventions, architecture, and constraints.
+
+## Behaviour
+
+1. Load the `ai-context` skill for templates and the codebase analysis workflow
+2. Load the `doc-standards` rule for quality criteria
+3. Run the codebase analysis: detect language, framework, test runner, linter, conventions
+4. Generate the requested context file(s) from the analysis results
+
+## Arguments
+
+- **No arguments**: Generate all applicable context files (AGENTS.md, CLAUDE.md, .cursorrules, .github/copilot-instructions.md)
+- `claude`: Generate CLAUDE.md only
+- `agents`: Generate AGENTS.md only
+- `cursor`: Generate .cursorrules only
+- `copilot`: Generate .github/copilot-instructions.md only
+- `audit`: Check existing context files for staleness and drift against the current codebase
+
+## Output
+
+Each generated file is written directly to disk. The audit mode reports findings without modifying files:
+
+```
+AI Context Files:
+  ✓ AGENTS.md — generated (45 lines)
+  ✓ CLAUDE.md — generated (38 lines)
+  ✓ .cursorrules — generated (22 lines)
+  ✓ .github/copilot-instructions.md — generated (30 lines)
+```
+
+Audit mode:
+```
+AI Context Audit:
+  ✓ AGENTS.md — up to date
+  ⚠ CLAUDE.md — references jest but vitest.config.ts detected
+  ✗ .cursorrules — references src/index.ts but file moved to src/main.ts
+  · .github/copilot-instructions.md — not present (recommend generating)
+```

--- a/commands/docs-audit.md
+++ b/commands/docs-audit.md
@@ -49,6 +49,57 @@ Check what public-facing documentation is missing or needs improvement.
 | Low | docs/README.md | ? |
 | Low | docs/guides/ | ? |
 | Low | CITATION.cff | ? |
+| Medium | AGENTS.md | ? |
+| Medium | .github/copilot-instructions.md | ? |
+| Low | CLAUDE.md | ? |
+| Low | .cursorrules | ? |
+
+### AI Context Files Check
+
+If the project has AI context files, verify they reflect the current codebase:
+
+- [ ] AGENTS.md references correct language/framework version
+- [ ] AGENTS.md key commands are runnable (`test`, `build`, `lint`)
+- [ ] CLAUDE.md file paths exist on disk
+- [ ] .cursorrules conventions match current linter config
+- [ ] .github/copilot-instructions.md patterns are consistent with codebase
+
+Report format:
+```
+AI Context Files:
+  ✓ AGENTS.md — present, references TypeScript + Vitest (matches codebase)
+  ⚠ CLAUDE.md — references src/index.ts but file is now src/main.ts
+  · .cursorrules — not present (recommend: run /ai-context cursor)
+  · .github/copilot-instructions.md — not present (recommend: run /ai-context copilot)
+```
+
+### Diataxis Coverage Check
+
+Classify existing docs into Diataxis quadrants and flag gaps:
+
+- [ ] At least one How-to Guide exists (docs/guides/)
+- [ ] Tutorial exists for onboarding (docs/tutorials/) — optional for small projects
+- [ ] Reference docs exist for public API (docs/reference/ or docs/api/) — if applicable
+- [ ] Explanation docs exist for architecture decisions — optional for small projects
+
+Report format:
+```
+Diataxis Coverage:
+  ✓ How-to Guides: 4 docs (getting-started, configuration, deployment, troubleshooting)
+  · Tutorials: 0 docs (consider adding for complex onboarding)
+  ✓ Reference: 1 doc (api.md)
+  · Explanation: 0 docs (consider adding architecture decisions doc)
+```
+
+### Documentation Verification Check
+
+If the `docs-verify` skill is loaded, also run:
+- [ ] All internal links resolve
+- [ ] llms.txt references match files on disk
+- [ ] No stale docs (>90 days without update, relative to last commit)
+- [ ] Badge URLs return valid responses
+
+Recommend: run `/docs-verify` for the full verification report.
 
 ### Quality Check (Is the content good?)
 

--- a/commands/docs-verify.md
+++ b/commands/docs-verify.md
@@ -1,0 +1,60 @@
+---
+description: "Verify documentation quality, links, freshness, and consistency: $ARGUMENTS"
+argument-hint: "[links|freshness|ci] or no args for all checks"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# /docs-verify
+
+Validate that documentation remains accurate, linked, and fresh over time. Catches broken links, stale content, and llms.txt drift before they reach users.
+
+## Behaviour
+
+1. Load the `docs-verify` skill for the verification checks
+2. Scan all Markdown files in the repository
+3. Run the requested checks (or all checks if no arguments)
+4. Report findings with severity levels
+
+## Arguments
+
+- **No arguments**: Run all checks and report findings
+- `links`: Link validation only (internal + external)
+- `freshness`: Staleness check only (git blame-based)
+- `ci`: All checks, output in CI-friendly format (exit code 1 on errors, file:line format)
+
+## Checks Performed
+
+| Check | What It Catches |
+|-------|----------------|
+| Markdown lint | Heading hierarchy skips, single H1 rule, formatting |
+| Link validation | Broken relative paths, dead external URLs, missing anchors |
+| llms.txt sync | Files referenced in llms.txt that no longer exist, orphaned docs |
+| Image validation | Missing image files, empty alt text, relative URLs for npm/PyPI projects |
+| Freshness | Docs not updated in 90+ days (configurable via git blame) |
+| Feature coverage | README features vs actual code — undocumented and over-documented |
+| Badge URLs | Shields.io badges returning errors or outdated formats |
+
+## Output Format
+
+```
+📋 Documentation Verification: [project-name]
+
+Markdown Lint:       ✓ 12 files checked, 0 issues
+Link Validation:     ⚠ 45 links checked, 2 warnings, 1 error
+llms.txt Sync:       ✓ 12/12 references valid
+Image Validation:    ⚠ 3 images checked, 1 warning
+Freshness:           ⚠ 2 files stale (>90 days)
+Feature Coverage:    ✓ 8/10 features documented (80%)
+Badge URLs:          ✓ 5/5 badges valid
+
+Errors (must fix):
+  ✗ README.md:89 — broken link: docs/guides/migration.md (file not found)
+
+Warnings (should fix):
+  ⚠ docs/guides/deployment.md — stale: last updated 95 days ago
+  ⚠ README.md:15 — relative image path, will break on npm
+```

--- a/commands/launch.md
+++ b/commands/launch.md
@@ -1,0 +1,62 @@
+---
+description: "Generate platform-specific launch and promotion artifacts from README/CHANGELOG: $ARGUMENTS"
+argument-hint: "[devto|hn|reddit|social|awesome] or no args for all"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - Write
+  - Edit
+  - mcp__github__search_repositories
+---
+
+# /launch
+
+Transform your README and CHANGELOG into platform-specific posts for launching or announcing your project. Every artifact is derived from existing code and documentation — no generic marketing.
+
+## Behaviour
+
+1. Load the `launch-artifacts` skill for platform templates
+2. Load the `feature-benefits` skill for feature extraction (if not already done)
+3. Read README.md and CHANGELOG.md for source content
+4. Generate the requested artifact(s) from the source content
+5. Write artifacts to `docs/launch/` directory (not committed by default — review before posting)
+
+## Arguments
+
+- **No arguments**: Generate all applicable launch artifacts
+- `devto`: Dev.to article only
+- `hn`: Hacker News "Show HN" post only
+- `reddit`: Reddit post templates only
+- `social`: Social preview image guidance + Twitter/X thread
+- `awesome`: Awesome list submission PR template (searches for relevant awesome lists)
+
+## Output
+
+Generated artifacts are written to `docs/launch/`:
+
+```
+docs/launch/
+├── devto-article.md          # Dev.to article with frontmatter
+├── hackernews-post.md         # HN title + first comment
+├── reddit-post.md             # Reddit posts for relevant subreddits
+├── twitter-thread.md          # 5-tweet thread
+├── awesome-list-submission.md # PR template for awesome list submissions
+└── social-preview-guide.md    # Social preview image specifications
+```
+
+```
+📋 Launch Artifacts: [project-name]
+
+  ✓ docs/launch/devto-article.md — 45 lines (review tags before publishing)
+  ✓ docs/launch/hackernews-post.md — title: 72 chars (under 80 limit)
+  ✓ docs/launch/reddit-post.md — 3 subreddit variants
+  ✓ docs/launch/twitter-thread.md — 5 tweets (all under 280 chars)
+  ✓ docs/launch/awesome-list-submission.md — 2 relevant lists found
+  ✓ docs/launch/social-preview-guide.md — dimensions and design tips
+
+Timing recommendation:
+  Best HN posting window: Tue–Thu, 9–11 AM US Eastern
+  Space Reddit posts across subreddits by 24+ hours
+```

--- a/llms.txt
+++ b/llms.txt
@@ -1,24 +1,28 @@
 # PitchDocs
 
-> GitHub repository documentation skills and templates for AI coding assistants. A Claude Code plugin that scans codebases, extracts features with file-level evidence, and generates marketing-quality docs — README, CHANGELOG, ROADMAP, user guides, llms.txt, and 17+ files total. Pure Markdown, zero runtime dependencies. Also works with OpenCode, Codex CLI, Cursor, Gemini CLI, Aider, and Goose.
+> GitHub repository documentation skills and templates for AI coding assistants. A Claude Code plugin that scans codebases, extracts features with file-level evidence, and generates marketing-quality docs — README, CHANGELOG, ROADMAP, user guides, llms.txt, AI context files, launch artifacts, and 20+ files total. GEO-optimised for AI citation. Pure Markdown, zero runtime dependencies. Also works with OpenCode, Codex CLI, Cursor, Gemini CLI, Aider, and Goose.
 
 ## Docs
 
 - [README](./README.md): Project overview, value proposition, quick start, commands table, skills table, and setup instructions for 7 AI coding tools
 - [Contributing](./CONTRIBUTING.md): Development setup, how to improve templates, add skills/commands, and submit PRs using conventional commits
-- [Changelog](./CHANGELOG.md): Version history from v1.0.0 to v1.4.1 with user-facing change descriptions
+- [Changelog](./CHANGELOG.md): Version history from v1.0.0 to v1.5.0 with user-facing change descriptions
 - [Agents.md](./AGENTS.md): Codex CLI compatibility file with condensed skills reference and docs-writer agent overview
 
 ## Skills
 
-- [Public README](./.claude/skills/public-readme/SKILL.md): Three-part hero structure, use-case framing, bold+em-dash features, and the Daytona/Banesullivan marketing framework for README generation
+- [Public README](./.claude/skills/public-readme/SKILL.md): Three-part hero structure, use-case framing, bold+em-dash features, GEO patterns for AI citation, and the Daytona/Banesullivan marketing framework for README generation
 - [Feature Benefits](./.claude/skills/feature-benefits/SKILL.md): 5-step codebase scanning workflow across 10 signal categories with evidence-based benefit translation
 - [Changelog](./.claude/skills/changelog/SKILL.md): Keep a Changelog format with language rules that rewrite commits into user-facing benefit language
 - [Roadmap](./.claude/skills/roadmap/SKILL.md): ROADMAP.md structure from GitHub milestones with emoji status indicators and community involvement section
-- [PitchDocs Suite](./.claude/skills/pitchdocs-suite/SKILL.md): 17+ file inventory, GitHub metadata, visual assets, licence selection, and ready-to-use templates for the full docs suite
+- [PitchDocs Suite](./.claude/skills/pitchdocs-suite/SKILL.md): 20+ file inventory, GitHub metadata, AI context files, visual assets, licence selection, and ready-to-use templates for the full docs suite
 - [llms.txt](./.claude/skills/llms-txt/SKILL.md): llmstxt.org specification reference with generation patterns for repositories and documentation sites
 - [Package Registry](./.claude/skills/package-registry/SKILL.md): npm and PyPI metadata auditing, README cross-renderer compatibility, trusted publishing, and registry badges
-- [User Guides](./.claude/skills/user-guides/SKILL.md): Task-oriented how-to documentation with numbered steps, verification, and cross-linked hub pages
+- [User Guides](./.claude/skills/user-guides/SKILL.md): Task-oriented how-to documentation with Diataxis framework, numbered steps, copy-paste-ready code, error recovery, and cross-linked hub pages
+- [AI Context](./.claude/skills/ai-context/SKILL.md): AI IDE context file generation — AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md from codebase analysis with staleness audit
+- [Docs Verify](./.claude/skills/docs-verify/SKILL.md): Documentation validation — broken links, stale content, llms.txt sync, heading hierarchy, badge URLs, and CI-friendly output with GitHub Actions template
+- [Launch Artifacts](./.claude/skills/launch-artifacts/SKILL.md): Platform-specific launch content — Dev.to articles, Hacker News posts, Reddit posts, Twitter/X threads, awesome list submissions, and social preview guidance
+- [API Reference](./.claude/skills/api-reference/SKILL.md): API reference generator guidance — TypeDoc, Sphinx, godoc, rustdoc configuration templates and docstring conventions
 
 ## Agent
 
@@ -30,9 +34,12 @@
 - [/features](./commands/features.md): Extract features from code and translate to benefits
 - [/changelog](./commands/changelog.md): Generate CHANGELOG.md from git history
 - [/roadmap](./commands/roadmap.md): Generate ROADMAP.md from GitHub milestones
-- [/docs-audit](./commands/docs-audit.md): Audit docs completeness against 17+ file checklist
+- [/docs-audit](./commands/docs-audit.md): Audit docs completeness against 20+ file checklist with AI context and Diataxis coverage
 - [/llms-txt](./commands/llms-txt.md): Generate llms.txt and llms-full.txt
-- [/user-guide](./commands/user-guide.md): Generate task-oriented user guides
+- [/user-guide](./commands/user-guide.md): Generate task-oriented user guides with Diataxis classification
+- [/ai-context](./commands/ai-context.md): Generate AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md)
+- [/docs-verify](./commands/docs-verify.md): Verify documentation links, freshness, llms.txt sync, and badge URLs
+- [/launch](./commands/launch.md): Generate platform-specific launch artifacts (Dev.to, HN, Reddit, Twitter, awesome lists)
 
 ## Optional
 
@@ -40,5 +47,5 @@
 - [Code of Conduct](./CODE_OF_CONDUCT.md): Community behaviour standards (Contributor Covenant v3.0)
 - [License](./LICENSE): MIT licence terms
 - [Plugin Manifest](./.claude-plugin/plugin.json): Plugin metadata, version, keywords, and author info
-- [Doc Standards](./.claude/rules/doc-standards.md): Auto-loaded quality rule — 4-question framework, progressive disclosure, benefit-driven language, visual formatting
+- [Doc Standards](./.claude/rules/doc-standards.md): Auto-loaded quality rule — 4-question framework, GEO optimisation, progressive disclosure, benefit-driven language, visual formatting
 - [Upstream Versions](./upstream-versions.json): Pinned versions of referenced specifications (Keep a Changelog, Contributor Covenant, Conventional Commits, Semantic Versioning)


### PR DESCRIPTION
## Summary

PitchDocs v1.5.0 adds four new capability pillars to the plugin:

- **GEO-optimised content generation** — Baked into existing skills (public-readme, user-guides) and the doc-standards rule. Crisp definitions, atomic sections, comparison tables, and concrete statistics structured for LLM extraction and AI citation (based on the Princeton GEO study showing 28% visibility boost).
- **AI context file generation** — New `ai-context` skill and `/ai-context` command. Generates AGENTS.md, CLAUDE.md, .cursorrules, and copilot-instructions.md from codebase analysis so AI coding assistants understand project conventions from day one.
- **Documentation verification** — New `docs-verify` skill and `/docs-verify` command. Validates broken links, stale content, llms.txt sync, heading hierarchy, badge URLs — locally or in CI.
- **Launch artifacts** — New `launch-artifacts` skill and `/launch` command. Transforms README and CHANGELOG into Dev.to articles, Hacker News posts, Reddit posts, Twitter/X threads, and awesome list submission PRs.

### Additional enhancements

- **Diataxis framework** integrated into user-guides skill (tutorials, how-to, reference, explanation quadrants)
- **API reference skill** with TypeDoc, Sphinx, godoc, and rustdoc configuration guidance
- **Docs-audit expanded** to check AI context files, Diataxis coverage, and documentation verification
- **Inventory expanded** from 17+ to 20+ files across all tiers (AI context files added to Tier 2 and Tier 3)
- **All cross-references updated** — README, AGENTS.md, CONTRIBUTING.md, llms.txt, CHANGELOG now consistently reflect 12 skills, 10 commands, 20+ file inventory

### Files changed

**New files (7):**
- `.claude/skills/ai-context/SKILL.md` — AI IDE context file generation
- `.claude/skills/api-reference/SKILL.md` — API reference generator guidance
- `.claude/skills/docs-verify/SKILL.md` — Documentation validation
- `.claude/skills/launch-artifacts/SKILL.md` — Launch content generation
- `commands/ai-context.md` — `/ai-context` slash command
- `commands/docs-verify.md` — `/docs-verify` slash command
- `commands/launch.md` — `/launch` slash command

**Modified files (12):**
- `.claude-plugin/plugin.json` — Version 1.5.0, new keywords
- `.claude/agents/docs-writer.md` — References 4 new skills
- `.claude/rules/doc-standards.md` — GEO section (7 subsections)
- `.claude/skills/pitchdocs-suite/SKILL.md` — AI context files in inventory
- `.claude/skills/public-readme/SKILL.md` — GEO patterns
- `.claude/skills/user-guides/SKILL.md` — Diataxis framework + advanced patterns
- `AGENTS.md` — 12 skills, 10 commands, GEO description
- `CHANGELOG.md` — v1.5.0 entry
- `CONTRIBUTING.md` — File tree with 12 skill directories
- `README.md` — GEO value proposition, updated counts, new features
- `commands/docs-audit.md` — AI context + Diataxis + verification checks
- `llms.txt` — Updated with all new files

## Test plan

- [ ] Verify `plugin.json` is valid JSON with correct version (1.5.0) and 10 registered commands
- [ ] Verify all 12 SKILL.md files exist and have valid YAML frontmatter
- [ ] Verify all 10 command files exist and have valid YAML frontmatter
- [ ] Verify README renders correctly on GitHub (badge URLs, anchor links, tables)
- [ ] Verify AGENTS.md has 12 skill rows and 10 command rows
- [ ] Verify CONTRIBUTING.md file tree shows 12 skill directories
- [ ] Verify llms.txt references match actual files on disk
- [ ] Verify no stale references to "17+", "8 skills", or "7 commands" remain (except CHANGELOG's intentional "from 17+ to 20+")

🤖 Generated with [Claude Code](https://claude.com/claude-code)