### PR TITLE
docs: use pitchdocs: namespace prefix for all user-facing commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ PitchDocs is a Claude Code plugin that generates marketing-quality repository do
 - `.claude/rules/context-quality.md` — AI context file quality rule (auto-loaded, Claude Code only)
 - `.claude/rules/content-filter.md` — content filter quick reference rule (auto-loaded, Claude Code only)
 - `commands/*.md` — 12 slash command definitions
-- `hooks/*.sh` — 3 Context Guard hook scripts (Claude Code only, opt-in via `/context-guard install`)
+- `hooks/*.sh` — 3 Context Guard hook scripts (Claude Code only, opt-in via `/pitchdocs:context-guard install`)
 - `.claude-plugin/plugin.json` — plugin manifest
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The docs-writer agent (`.claude/agents/docs-writer.md`) orchestrates the full do
 
 ## Workflow Commands
 
-These commands are defined in `commands/*.md` and can be invoked as slash commands in Claude Code and OpenCode, or as prompts in Codex CLI. Commands marked *(Claude Code only)* use features not available in other tools:
+These commands are defined in `commands/*.md` and can be invoked as slash commands in Claude Code and OpenCode, or as prompts in Codex CLI. Claude Code users: invoke as `/pitchdocs:command-name` (e.g., `/pitchdocs:readme`). Commands marked *(Claude Code only)* use features not available in other tools:
 
 | Command | What It Does |
 |---------|-------------|
@@ -74,7 +74,7 @@ These commands are defined in `commands/*.md` and can be invoked as slash comman
 PitchDocs includes features that are specific to Claude Code and do not work in OpenCode, Codex CLI, or other tools:
 
 - **Rules** (3): `.claude/rules/doc-standards.md` (quality standards — 4-question framework, GEO, device screenshot dimensions, caption patterns, shadow/border guidance, auto-loaded), `.claude/rules/context-quality.md` (AI context file quality, auto-loaded), and `.claude/rules/content-filter.md` (content filter quick reference, auto-loaded)
-- **Hooks** (3): `hooks/context-drift-check.sh` (post-commit drift detection), `hooks/context-structural-change.sh` (structural change reminders), and `hooks/content-filter-guard.sh` (Write guard for high-risk OSS files) — opt-in via `/context-guard install`
+- **Hooks** (3): `hooks/context-drift-check.sh` (post-commit drift detection), `hooks/context-structural-change.sh` (structural change reminders), and `hooks/content-filter-guard.sh` (Write guard for high-risk OSS files) — opt-in via `/pitchdocs:context-guard install` (Claude Code)
 
 ## AI Context Files
 

--- a/README.md
+++ b/README.md
@@ -42,17 +42,19 @@ Get your first generated README in under 60 seconds.
 /plugin install pitchdocs@lba-plugins
 
 # 3. Generate a README for any project
-/readme
+/pitchdocs:readme
 ```
+
+**Note:** When installed as a plugin, all commands use the `pitchdocs:` prefix (e.g., `/pitchdocs:readme`). The short form `/readme` only works inside the pitchdocs source directory.
 
 **Optional — install Context Guard hooks (Claude Code only):**
 
 ```bash
 # 4. Install Context Guard hooks for AI context file freshness and content filter protection
-/context-guard install
+/pitchdocs:context-guard install
 ```
 
-Keeps your AI context files (AGENTS.md, CLAUDE.md, etc.) in sync as your project evolves, and prevents content filter errors when generating standard OSS files (CODE_OF_CONDUCT, LICENSE, SECURITY). Uninstall anytime with `/context-guard uninstall`.
+Keeps your AI context files (AGENTS.md, CLAUDE.md, etc.) in sync as your project evolves, and prevents content filter errors when generating standard OSS files (CODE_OF_CONDUCT, LICENSE, SECURITY). Uninstall anytime with `/pitchdocs:context-guard uninstall`.
 
 OpenCode reads `.claude/skills/` natively — the same install steps (1–3) work in both tools.
 
@@ -64,7 +66,7 @@ OpenCode reads `.claude/skills/` natively — the same install steps (1–3) wor
 
 Your repo is ready to go public, but the docs aren't. You need a README that sells, a CHANGELOG that makes sense to users, a SECURITY policy, contributing guidelines, issue templates, PR templates — and it all needs to look professional.
 
-PitchDocs gives your AI coding assistant the skills and knowledge to scan your codebase, find what's worth talking about, and write the whole documentation suite for you. README, CHANGELOG, CONTRIBUTING, ROADMAP, CODE_OF_CONDUCT, SECURITY, issue templates, PR templates, user guides, AI context files, and `llms.txt` — all from slash commands like `/readme` and `/docs-audit fix`.
+PitchDocs gives your AI coding assistant the skills and knowledge to scan your codebase, find what's worth talking about, and write the whole documentation suite for you. README, CHANGELOG, CONTRIBUTING, ROADMAP, CODE_OF_CONDUCT, SECURITY, issue templates, PR templates, user guides, AI context files, and `llms.txt` — all from slash commands like `/pitchdocs:readme` and `/pitchdocs:docs-audit fix`.
 
 Every generated doc is GEO and SEO optimised, npm and PyPI registry compatible, and backed by evidence from your actual code.
 
@@ -97,7 +99,7 @@ Every generated doc is GEO and SEO optimised, npm and PyPI registry compatible, 
 |-----------|-----------|----------------|--------------------------------|--------------------------------------------------|-------------------|
 | Scans codebase for features | 10 signal categories with file-level evidence | You decide what to include | No | Basic directory scan | Depends on prompt quality |
 | Benefit-driven language | Built-in framework (5 categories, evidence required) | If you know how | No | AI-generated, unstructured | Hit or miss |
-| Full docs suite (20+ files) | One command: `/docs-audit fix` | Hours of manual work | README only | README only | One file at a time |
+| Full docs suite (20+ files) | One command: `/pitchdocs:docs-audit fix` | Hours of manual work | README only | README only | One file at a time |
 | GEO / AI citation optimised | Atomic sections, comparison tables, concrete stats, llms.txt | If you know GEO | No | No | No |
 | AI context files | AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md | Manual | No | No | No |
 | Launch artifacts | Dev.to, HN, Reddit, Twitter, awesome lists | Manual per platform | No | No | No |
@@ -112,31 +114,31 @@ Every generated doc is GEO and SEO optimised, npm and PyPI registry compatible, 
 
 | Command | What It Does | Why It Matters |
 |---------|-------------|----------------|
-| `/readme` | Generate or update a marketing-friendly README.md | First impressions that convert browsers to users |
-| `/features` | Extract features from code and translate to benefits — output as inventory, table, or emoji+bold+em-dash bullets | Never miss a feature worth documenting |
-| `/changelog` | Generate CHANGELOG.md from git history with user-benefit language | Users see what changed for *them*, not your commit log |
-| `/roadmap` | Generate ROADMAP.md from GitHub milestones and issues | Show contributors where the project is heading |
-| `/docs-audit` | Audit docs completeness, quality, GitHub metadata, visual assets, AI context files, Diataxis coverage, and npm/PyPI registry config | Catch gaps in files, metadata, images, and package registry fields before you ship |
-| `/llms-txt` | Generate llms.txt and llms-full.txt for AI discoverability | AI coding assistants and search engines find and understand your docs |
-| `/user-guide` | Generate task-oriented user guides in `docs/guides/` with Diataxis classification | Readers find answers without reading your source code |
-| `/ai-context` | Generate AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md from codebase analysis | AI coding assistants understand your project's conventions from day one |
-| `/docs-verify` | Verify links, freshness, llms.txt sync, heading hierarchy, and badge URLs | Catch documentation decay before it reaches users |
-| `/launch` | Generate Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions | Transform docs into platform-specific launch content |
-| `/doc-refresh` | Refresh all docs after version bumps — CHANGELOG, README features, user guides, AI context, llms.txt | Never ship a release with stale documentation |
-| `/context-guard` | Install, uninstall, or check status of Context Guard hooks for AI context file freshness and content filter protection | Catch stale context files and prevent content filter errors automatically |
+| `/pitchdocs:readme` | Generate or update a marketing-friendly README.md | First impressions that convert browsers to users |
+| `/pitchdocs:features` | Extract features from code and translate to benefits — output as inventory, table, or emoji+bold+em-dash bullets | Never miss a feature worth documenting |
+| `/pitchdocs:changelog` | Generate CHANGELOG.md from git history with user-benefit language | Users see what changed for *them*, not your commit log |
+| `/pitchdocs:roadmap` | Generate ROADMAP.md from GitHub milestones and issues | Show contributors where the project is heading |
+| `/pitchdocs:docs-audit` | Audit docs completeness, quality, GitHub metadata, visual assets, AI context files, Diataxis coverage, and npm/PyPI registry config | Catch gaps in files, metadata, images, and package registry fields before you ship |
+| `/pitchdocs:llms-txt` | Generate llms.txt and llms-full.txt for AI discoverability | AI coding assistants and search engines find and understand your docs |
+| `/pitchdocs:user-guide` | Generate task-oriented user guides in `docs/guides/` with Diataxis classification | Readers find answers without reading your source code |
+| `/pitchdocs:ai-context` | Generate AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md from codebase analysis | AI coding assistants understand your project's conventions from day one |
+| `/pitchdocs:docs-verify` | Verify links, freshness, llms.txt sync, heading hierarchy, and badge URLs | Catch documentation decay before it reaches users |
+| `/pitchdocs:launch` | Generate Dev.to articles, HN posts, Reddit posts, Twitter threads, awesome list submissions | Transform docs into platform-specific launch content |
+| `/pitchdocs:doc-refresh` | Refresh all docs after version bumps — CHANGELOG, README features, user guides, AI context, llms.txt | Never ship a release with stale documentation |
+| `/pitchdocs:context-guard` | Install, uninstall, or check status of Context Guard hooks for AI context file freshness and content filter protection | Catch stale context files and prevent content filter errors automatically |
 
-**Note:** `/context-guard` is **Claude Code only**. All other commands work across all supported AI tools.
+**Note:** `/pitchdocs:context-guard` is **Claude Code only**. All other commands work across all supported AI tools.
 
 ### Quick Examples
 
 ```bash
-/readme                   # Generate a marketing-friendly README
-/features bullets         # Extract features as emoji+bold+em-dash bullets
-/docs-audit fix           # Audit and auto-generate missing docs
-/changelog full           # Generate full changelog from all tags
-/ai-context               # Generate AI context files for all tools
-/docs-verify              # Check for broken links and stale content
-/doc-refresh              # Refresh all docs for an upcoming release
+/pitchdocs:readme                   # Generate a marketing-friendly README
+/pitchdocs:features bullets         # Extract features as emoji+bold+em-dash bullets
+/pitchdocs:docs-audit fix           # Audit and auto-generate missing docs
+/pitchdocs:changelog full           # Generate full changelog from all tags
+/pitchdocs:ai-context               # Generate AI context files for all tools
+/pitchdocs:docs-verify              # Check for broken links and stale content
+/pitchdocs:doc-refresh              # Refresh all docs for an upcoming release
 ```
 
 ---

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -13,9 +13,11 @@ order: 3
 
 > **Summary**: All 12 PitchDocs commands with arguments, generated files, and examples.
 
+**Note:** When installed as a plugin, all commands use the `pitchdocs:` prefix (e.g., `/pitchdocs:readme`). The short form `/readme` only works inside the pitchdocs source directory.
+
 ---
 
-## `/readme`
+## `/pitchdocs:readme`
 
 Generate or update a marketing-friendly README.md.
 
@@ -27,16 +29,16 @@ Generate or update a marketing-friendly README.md.
 
 **Examples:**
 ```
-/readme                              # Generate for current project
-/readme packages/api                 # Generate for a specific package
-/readme focus on the comparison table # Steer output to a specific section
+/pitchdocs:readme                              # Generate for current project
+/pitchdocs:readme packages/api                 # Generate for a specific package
+/pitchdocs:readme focus on the comparison table # Steer output to a specific section
 ```
 
 If a README.md already exists, PitchDocs reads it first and improves it rather than replacing from scratch.
 
 ---
 
-## `/features`
+## `/pitchdocs:features`
 
 Extract features from code and translate to benefits.
 
@@ -48,15 +50,15 @@ Extract features from code and translate to benefits.
 
 **Examples:**
 ```
-/features                # Full inventory (Hero / Core / Supporting tiers)
-/features table          # Markdown table format
-/features bullets        # Emoji+bold+em-dash bullet format
-/features audit          # Compare extracted vs documented features
+/pitchdocs:features                # Full inventory (Hero / Core / Supporting tiers)
+/pitchdocs:features table          # Markdown table format
+/pitchdocs:features bullets        # Emoji+bold+em-dash bullet format
+/pitchdocs:features audit          # Compare extracted vs documented features
 ```
 
 ---
 
-## `/docs-audit`
+## `/pitchdocs:docs-audit`
 
 Audit documentation completeness against a 20+ file checklist.
 
@@ -68,16 +70,16 @@ Audit documentation completeness against a 20+ file checklist.
 
 **Examples:**
 ```
-/docs-audit              # Report what's missing
-/docs-audit fix          # Auto-generate all missing docs
-/docs-audit packages/ui  # Audit a specific directory
+/pitchdocs:docs-audit              # Report what's missing
+/pitchdocs:docs-audit fix          # Auto-generate all missing docs
+/pitchdocs:docs-audit packages/ui  # Audit a specific directory
 ```
 
 Checks across 3 priority tiers: Tier 1 (README, LICENSE, CONTRIBUTING), Tier 2 (CHANGELOG, SECURITY, CODE_OF_CONDUCT), and Tier 3 (llms.txt, AGENTS.md, templates).
 
 ---
 
-## `/docs-verify`
+## `/pitchdocs:docs-verify`
 
 Verify documentation quality, links, freshness, and consistency.
 
@@ -89,18 +91,18 @@ Verify documentation quality, links, freshness, and consistency.
 
 **Examples:**
 ```
-/docs-verify             # Run all 9 checks
-/docs-verify links       # Link validation only
-/docs-verify score       # Quality score only (0–100)
-/docs-verify ci          # CI-friendly format (exit codes)
-/docs-verify ci --min-score 70  # Fail if score below 70
+/pitchdocs:docs-verify             # Run all 9 checks
+/pitchdocs:docs-verify links       # Link validation only
+/pitchdocs:docs-verify score       # Quality score only (0–100)
+/pitchdocs:docs-verify ci          # CI-friendly format (exit codes)
+/pitchdocs:docs-verify ci --min-score 70  # Fail if score below 70
 ```
 
 Runs 9 checks: markdown lint, link validation, llms.txt sync, image validation, freshness, feature coverage, badge URLs, token audit, and security scan.
 
 ---
 
-## `/changelog`
+## `/pitchdocs:changelog`
 
 Generate CHANGELOG.md from git history using conventional commits.
 
@@ -112,16 +114,16 @@ Generate CHANGELOG.md from git history using conventional commits.
 
 **Examples:**
 ```
-/changelog               # Update [Unreleased] section only
-/changelog v1.5.0        # Generate entry for a specific version
-/changelog full          # Regenerate entire changelog from all tags
+/pitchdocs:changelog               # Update [Unreleased] section only
+/pitchdocs:changelog v1.5.0        # Generate entry for a specific version
+/pitchdocs:changelog full          # Regenerate entire changelog from all tags
 ```
 
 **Note:** CHANGELOG.md has medium content filter risk. PitchDocs uses chunked writing automatically.
 
 ---
 
-## `/roadmap`
+## `/pitchdocs:roadmap`
 
 Generate ROADMAP.md from GitHub milestones and issues.
 
@@ -133,16 +135,16 @@ Generate ROADMAP.md from GitHub milestones and issues.
 
 **Examples:**
 ```
-/roadmap                 # Generate from all milestones and issues
-/roadmap "v2.0"          # Focus on a specific milestone
-/roadmap full            # Regenerate from scratch
+/pitchdocs:roadmap                 # Generate from all milestones and issues
+/pitchdocs:roadmap "v2.0"          # Focus on a specific milestone
+/pitchdocs:roadmap full            # Regenerate from scratch
 ```
 
 Uses GitHub milestones, issues labelled `enhancement`/`feature`, and git tags for completed versions.
 
 ---
 
-## `/user-guide`
+## `/pitchdocs:user-guide`
 
 Generate task-oriented user guides in `docs/guides/`.
 
@@ -154,15 +156,15 @@ Generate task-oriented user guides in `docs/guides/`.
 
 **Examples:**
 ```
-/user-guide              # Auto-detect and generate most-needed guides
-/user-guide deployment   # Generate a specific guide
-/user-guide all          # Full guide suite
-/user-guide hub          # Hub page only (docs/README.md)
+/pitchdocs:user-guide              # Auto-detect and generate most-needed guides
+/pitchdocs:user-guide deployment   # Generate a specific guide
+/pitchdocs:user-guide all          # Full guide suite
+/pitchdocs:user-guide hub          # Hub page only (docs/README.md)
 ```
 
 ---
 
-## `/llms-txt`
+## `/pitchdocs:llms-txt`
 
 Generate llms.txt and llms-full.txt for AI discoverability.
 
@@ -174,15 +176,15 @@ Generate llms.txt and llms-full.txt for AI discoverability.
 
 **Examples:**
 ```
-/llms-txt                # Generate llms.txt only
-/llms-txt full           # Generate both llms.txt and llms-full.txt
+/pitchdocs:llms-txt                # Generate llms.txt only
+/pitchdocs:llms-txt full           # Generate both llms.txt and llms-full.txt
 ```
 
 Follows the [llmstxt.org](https://llmstxt.org/) specification.
 
 ---
 
-## `/ai-context`
+## `/pitchdocs:ai-context`
 
 Generate AI IDE context files for 7 tools.
 
@@ -194,15 +196,15 @@ Generate AI IDE context files for 7 tools.
 
 **Examples:**
 ```
-/ai-context              # Generate all 7 context files
-/ai-context agents       # AGENTS.md only
-/ai-context cursor       # .cursorrules only
-/ai-context audit        # Check existing files for drift (no writes)
+/pitchdocs:ai-context              # Generate all 7 context files
+/pitchdocs:ai-context agents       # AGENTS.md only
+/pitchdocs:ai-context cursor       # .cursorrules only
+/pitchdocs:ai-context audit        # Check existing files for drift (no writes)
 ```
 
 ---
 
-## `/doc-refresh`
+## `/pitchdocs:doc-refresh`
 
 Refresh documentation after version bumps, feature additions, or periodic maintenance.
 
@@ -214,17 +216,17 @@ Refresh documentation after version bumps, feature additions, or periodic mainte
 
 **Examples:**
 ```
-/doc-refresh             # Auto-detect latest tag, refresh what changed
-/doc-refresh v1.7.0      # Refresh for a specific version
-/doc-refresh v1.5.0..v1.7.0  # Refresh for a version range
-/doc-refresh plan        # Dry run — report what needs refreshing
-/doc-refresh changelog   # Only refresh CHANGELOG.md
-/doc-refresh full        # Refresh everything regardless
+/pitchdocs:doc-refresh             # Auto-detect latest tag, refresh what changed
+/pitchdocs:doc-refresh v1.7.0      # Refresh for a specific version
+/pitchdocs:doc-refresh v1.5.0..v1.7.0  # Refresh for a version range
+/pitchdocs:doc-refresh plan        # Dry run — report what needs refreshing
+/pitchdocs:doc-refresh changelog   # Only refresh CHANGELOG.md
+/pitchdocs:doc-refresh full        # Refresh everything regardless
 ```
 
 ---
 
-## `/launch`
+## `/pitchdocs:launch`
 
 Generate platform-specific launch and promotion artifacts.
 
@@ -236,19 +238,19 @@ Generate platform-specific launch and promotion artifacts.
 
 **Examples:**
 ```
-/launch                  # Generate all launch artifacts
-/launch devto            # Dev.to article only
-/launch hn               # Hacker News "Show HN" post
-/launch reddit           # Reddit post templates
-/launch social           # Twitter/X thread + social preview guide
-/launch awesome          # Awesome list submission PR template
+/pitchdocs:launch                  # Generate all launch artifacts
+/pitchdocs:launch devto            # Dev.to article only
+/pitchdocs:launch hn               # Hacker News "Show HN" post
+/pitchdocs:launch reddit           # Reddit post templates
+/pitchdocs:launch social           # Twitter/X thread + social preview guide
+/pitchdocs:launch awesome          # Awesome list submission PR template
 ```
 
 All artifacts are written to `docs/launch/` for human review — they are starting points, not copy-paste-ready.
 
 ---
 
-## `/context-guard`
+## `/pitchdocs:context-guard`
 
 Install, uninstall, or check Context Guard hooks. **Claude Code only.**
 
@@ -260,9 +262,9 @@ Install, uninstall, or check Context Guard hooks. **Claude Code only.**
 
 **Examples:**
 ```
-/context-guard install   # Install 3 hooks into the current project
-/context-guard status    # Check installation state and run drift check
-/context-guard uninstall # Remove hooks (preserves other hooks)
+/pitchdocs:context-guard install   # Install 3 hooks into the current project
+/pitchdocs:context-guard status    # Check installation state and run drift check
+/pitchdocs:context-guard uninstall # Remove hooks (preserves other hooks)
 ```
 
 Installs 3 hooks: drift detection (warns after commits), structural change reminders (nudges on config changes), and content filter guard (prevents HTTP 400 on high-risk files).

--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -119,7 +119,7 @@ PitchDocs classifies documentation into four types (from the Diataxis framework)
 | Reference | Information | Information-oriented | Command Reference |
 | Explanation | Understanding | Understanding-oriented | This page |
 
-When PitchDocs generates guides with `/user-guide`, it classifies each guide into one of these types. This helps ensure the docs set covers all four quadrants rather than concentrating on just one.
+When PitchDocs generates guides with `/pitchdocs:user-guide`, it classifies each guide into one of these types. This helps ensure the docs set covers all four quadrants rather than concentrating on just one.
 
 ---
 

--- a/docs/guides/customising-output.md
+++ b/docs/guides/customising-output.md
@@ -26,17 +26,17 @@ Every PitchDocs command accepts natural language arguments that guide what it ge
 ### Focus on a section
 
 ```
-/readme focus on the comparison table
-/readme focus on the quickstart section
-/readme focus on badges and credibility signals
+/pitchdocs:readme focus on the comparison table
+/pitchdocs:readme focus on the quickstart section
+/pitchdocs:readme focus on badges and credibility signals
 ```
 
 ### Target a specific audience
 
 ```
-/readme for a technical audience familiar with TypeScript
-/readme for non-technical stakeholders
-/user-guide for DevOps engineers setting up CI/CD
+/pitchdocs:readme for a technical audience familiar with TypeScript
+/pitchdocs:readme for non-technical stakeholders
+/pitchdocs:user-guide for DevOps engineers setting up CI/CD
 ```
 
 ### Iterate on existing output
@@ -44,9 +44,9 @@ Every PitchDocs command accepts natural language arguments that guide what it ge
 Run commands multiple times with different focus areas:
 
 ```
-/readme                              # First pass — full generation
-/readme improve the features section # Second pass — refine specific section
-/readme add a comparison with Tool X # Third pass — add competitive positioning
+/pitchdocs:readme                              # First pass — full generation
+/pitchdocs:readme improve the features section # Second pass — refine specific section
+/pitchdocs:readme add a comparison with Tool X # Third pass — add competitive positioning
 ```
 
 PitchDocs reads existing content before generating, so each pass refines rather than replaces.
@@ -58,9 +58,9 @@ PitchDocs reads existing content before generating, so each pass refines rather 
 PitchDocs defaults to professional-yet-approachable, benefit-driven language. Adjust by describing the tone you want:
 
 ```
-/readme with a formal, enterprise tone
-/readme keep it casual and developer-friendly
-/readme minimal marketing — focus on technical accuracy
+/pitchdocs:readme with a formal, enterprise tone
+/pitchdocs:readme keep it casual and developer-friendly
+/pitchdocs:readme minimal marketing — focus on technical accuracy
 ```
 
 **What you can't override:** The 4-question test (Does this solve my problem? Can I use it? Who made it? Where do I learn more?) is always applied. Every feature claim still requires code evidence. These are structural quality standards, not tone.
@@ -72,10 +72,10 @@ PitchDocs defaults to professional-yet-approachable, benefit-driven language. Ad
 Point commands at specific packages rather than the repo root:
 
 ```
-/readme packages/api
-/features packages/ui
-/docs-audit packages/shared
-/user-guide packages/cli
+/pitchdocs:readme packages/api
+/pitchdocs:features packages/ui
+/pitchdocs:docs-audit packages/shared
+/pitchdocs:user-guide packages/cli
 ```
 
 Each package can have its own independent documentation set. PitchDocs scans only the targeted directory's manifest files, source code, and git history.
@@ -97,8 +97,8 @@ The core quality framework. Enforces:
 If PitchDocs generates content you find overly structured, it's following these rules. You can ask it to simplify:
 
 ```
-/readme without emoji headings
-/readme shorter features section — max 5 items
+/pitchdocs:readme without emoji headings
+/pitchdocs:readme shorter features section — max 5 items
 ```
 
 ### context-quality (Claude Code only)
@@ -113,13 +113,13 @@ Guides PitchDocs around Claude's content filter. You don't need to interact with
 
 ## Output Formats for Features
 
-The `/features` command supports multiple output formats:
+The `/pitchdocs:features` command supports multiple output formats:
 
 ```
-/features              # Structured inventory (Hero / Core / Supporting tiers)
-/features table        # | Feature | Benefit | Status | table format
-/features bullets      # Emoji+bold+em-dash bullet format
-/features audit        # Gap analysis: documented vs actual
+/pitchdocs:features              # Structured inventory (Hero / Core / Supporting tiers)
+/pitchdocs:features table        # | Feature | Benefit | Status | table format
+/pitchdocs:features bullets      # Emoji+bold+em-dash bullet format
+/pitchdocs:features audit        # Gap analysis: documented vs actual
 ```
 
 Choose the format that matches where you'll paste the output. `table` works well for comparison sections; `bullets` works well for features lists.
@@ -131,15 +131,15 @@ Choose the format that matches where you'll paste the output. `table` works well
 After a release, you don't always need to refresh everything. Target specific areas:
 
 ```
-/doc-refresh plan              # Dry run — see what needs updating
-/doc-refresh changelog         # Only CHANGELOG.md
-/doc-refresh readme            # Only README.md features and metrics
-/doc-refresh guides            # Only affected user guides
-/doc-refresh context           # Only AI context files and llms.txt
-/doc-refresh release-notes     # Only GitHub release body
+/pitchdocs:doc-refresh plan              # Dry run — see what needs updating
+/pitchdocs:doc-refresh changelog         # Only CHANGELOG.md
+/pitchdocs:doc-refresh readme            # Only README.md features and metrics
+/pitchdocs:doc-refresh guides            # Only affected user guides
+/pitchdocs:doc-refresh context           # Only AI context files and llms.txt
+/pitchdocs:doc-refresh release-notes     # Only GitHub release body
 ```
 
-Use `/doc-refresh plan` first to see what changed, then refresh selectively.
+Use `/pitchdocs:doc-refresh plan` first to see what changed, then refresh selectively.
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -41,6 +41,8 @@ Open Claude Code in your terminal and run:
 
 **Verify it worked:** The skills and commands are loaded automatically. You should see PitchDocs skills available when you start a new session.
 
+**Note:** When installed as a plugin, all commands use the `pitchdocs:` prefix (e.g., `/pitchdocs:readme`). The short form `/readme` only works inside the pitchdocs source directory.
+
 ---
 
 ## 2. Generate Your First README
@@ -48,7 +50,7 @@ Open Claude Code in your terminal and run:
 Navigate to the project you want to document, then run:
 
 ```bash
-/readme
+/pitchdocs:readme
 ```
 
 PitchDocs will:
@@ -66,13 +68,13 @@ PitchDocs will:
 Check what other docs your project needs:
 
 ```bash
-/docs-audit
+/pitchdocs:docs-audit
 ```
 
 This scans your repo against a 20+ file checklist across 3 priority tiers and reports what's missing. To auto-generate everything that's missing in one go:
 
 ```bash
-/docs-audit fix
+/pitchdocs:docs-audit fix
 ```
 
 ---
@@ -83,16 +85,16 @@ See what PitchDocs detects in your codebase:
 
 ```bash
 # Full feature inventory with evidence
-/features
+/pitchdocs:features
 
 # Output as a benefits table for your README
-/features table
+/pitchdocs:features table
 
 # Output as emoji+bold+em-dash bullets
-/features bullets
+/pitchdocs:features bullets
 
 # Audit: compare what's documented vs what's in the code
-/features audit
+/pitchdocs:features audit
 ```
 
 ---
@@ -102,13 +104,13 @@ See what PitchDocs detects in your codebase:
 Use any command on its own for specific doc types:
 
 ```bash
-/changelog          # CHANGELOG.md from git history
-/roadmap            # ROADMAP.md from GitHub milestones
-/user-guide         # User guides in docs/guides/
-/llms-txt           # llms.txt for AI discoverability
-/ai-context         # AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md
-/docs-verify        # Validate links, freshness, and consistency
-/launch             # Dev.to articles, HN posts, Reddit posts, Twitter threads
+/pitchdocs:changelog          # CHANGELOG.md from git history
+/pitchdocs:roadmap            # ROADMAP.md from GitHub milestones
+/pitchdocs:user-guide         # User guides in docs/guides/
+/pitchdocs:llms-txt           # llms.txt for AI discoverability
+/pitchdocs:ai-context         # AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md
+/pitchdocs:docs-verify        # Validate links, freshness, and consistency
+/pitchdocs:launch             # Dev.to articles, HN posts, Reddit posts, Twitter threads
 ```
 
 ---
@@ -118,7 +120,7 @@ Use any command on its own for specific doc types:
 Before shipping your docs, run the verification suite:
 
 ```bash
-/docs-verify
+/pitchdocs:docs-verify
 ```
 
 This checks for:
@@ -138,7 +140,7 @@ This checks for:
 Context Guard adds three hooks to your project that run automatically during your Claude Code sessions:
 
 ```bash
-/context-guard install
+/pitchdocs:context-guard install
 ```
 
 What it installs:
@@ -147,7 +149,7 @@ What it installs:
 - **Structural change reminders** — nudges you to update context files when you modify commands, skills, or config
 - **Content filter guard** — prevents content filter errors (HTTP 400) by intercepting Write operations on files like CODE_OF_CONDUCT.md, LICENSE, and SECURITY.md, advising you to fetch them from canonical URLs instead
 
-Check status anytime with `/context-guard status`. Uninstall with `/context-guard uninstall`.
+Check status anytime with `/pitchdocs:context-guard status`. Uninstall with `/pitchdocs:context-guard uninstall`.
 
 **Note:** These hooks are Claude Code-specific. If your team uses OpenCode or Codex CLI alongside Claude Code, the hooks are silently ignored by those tools.
 
@@ -155,10 +157,10 @@ Check status anytime with `/context-guard status`. Uninstall with `/context-guar
 
 ## What's Next?
 
-- **Improve your README further** — Run `/readme` again with specific focus areas (e.g., `/readme focus on the comparison table`)
-- **Check your quality score** — Run `/docs-verify score` to get a numeric rating and actionable suggestions for improvement
-- **Set up CI verification** — The `/docs-verify` command outputs CI-friendly results for GitHub Actions
-- **Launch your project** — Run `/launch` to generate Dev.to articles, Hacker News posts, and awesome list submissions
+- **Improve your README further** — Run `/pitchdocs:readme` again with specific focus areas (e.g., `/pitchdocs:readme focus on the comparison table`)
+- **Check your quality score** — Run `/pitchdocs:docs-verify score` to get a numeric rating and actionable suggestions for improvement
+- **Set up CI verification** — The `/pitchdocs:docs-verify` command outputs CI-friendly results for GitHub Actions
+- **Launch your project** — Run `/pitchdocs:launch` to generate Dev.to articles, Hacker News posts, and awesome list submissions
 - **Explore skills** — Each command loads specialised reference knowledge. See the [Available Skills](../../AGENTS.md#available-skills) table for the full inventory.
 
 ---

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -40,7 +40,7 @@ curl -sL "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MIT
 curl -sL "https://raw.githubusercontent.com/github/.github/main/SECURITY.md" -o SECURITY.md
 ```
 
-After fetching, use `/readme` or manual edits to customise placeholders like `[INSERT CONTACT METHOD]`.
+After fetching, use `/pitchdocs:readme` or manual edits to customise placeholders like `[INSERT CONTACT METHOD]`.
 
 **Medium-risk files** (`CHANGELOG.md`, `CONTRIBUTING.md`):
 - Write in chunks — 5 to 10 entries at a time
@@ -60,7 +60,7 @@ After fetching, use `/readme` or manual edits to customise placeholders like `[I
 
 ## Quality Score Interpretation
 
-When you run `/docs-verify score`, PitchDocs rates your documentation across 5 dimensions (total: 0–100):
+When you run `/pitchdocs:docs-verify score`, PitchDocs rates your documentation across 5 dimensions (total: 0–100):
 
 | Dimension | Max Points | What It Measures |
 |-----------|-----------|------------------|
@@ -81,11 +81,11 @@ When you run `/docs-verify score`, PitchDocs rates your documentation across 5 d
 | Below 60 | F | Not ready |
 
 **Improving your score:**
-- **Completeness**: Run `/docs-audit fix` to auto-generate missing files
+- **Completeness**: Run `/pitchdocs:docs-audit fix` to auto-generate missing files
 - **Structure**: Ensure README has a hero section (logo + one-liner + badges), uses heading hierarchy without skipping levels (H1 > H2 > H3, never H1 > H3)
-- **Freshness**: Run `/doc-refresh` after releases or feature additions
-- **Link Health**: Run `/docs-verify links` and fix reported broken links
-- **Evidence**: Run `/features audit` to find undocumented features, then update README
+- **Freshness**: Run `/pitchdocs:doc-refresh` after releases or feature additions
+- **Link Health**: Run `/pitchdocs:docs-verify links` and fix reported broken links
+- **Evidence**: Run `/pitchdocs:features audit` to find undocumented features, then update README
 
 ---
 
@@ -93,16 +93,16 @@ When you run `/docs-verify score`, PitchDocs rates your documentation across 5 d
 
 ### PitchDocs missed a feature
 
-`/features` scans 10 signal categories. If it missed something:
+`/pitchdocs:features` scans 10 signal categories. If it missed something:
 
 1. Check that the feature has code evidence — PitchDocs requires file-level proof (a file path, function name, or config option) for every feature claim
 2. Ensure the feature falls within the 10 signal categories: CLI commands, public API, configuration, integrations, performance, security, TypeScript/DX, testing, middleware/plugins/extensibility, and documentation
-3. Try running `/features` with a specific focus: describe the feature area in your prompt (e.g., `/features focus on the webhook integration`)
+3. Try running `/pitchdocs:features` with a specific focus: describe the feature area in your prompt (e.g., `/pitchdocs:features focus on the webhook integration`)
 4. For features only visible at runtime (e.g. env-var-controlled behaviour), add an `.env.example` or config schema — PitchDocs scans these
 
 ### PitchDocs listed a feature that doesn't exist
 
-Run `/features audit` to compare extracted features against what's documented in README. Over-documented features (claimed but not found in code) are flagged. Remove them from README or add the missing implementation.
+Run `/pitchdocs:features audit` to compare extracted features against what's documented in README. Over-documented features (claimed but not found in code) are flagged. Remove them from README or add the missing implementation.
 
 ---
 
@@ -112,7 +112,7 @@ Run `/features audit` to compare extracted features against what's documented in
 
 - Check the badge URL directly in a browser — shields.io returns SVGs, so a 404 or error SVG indicates a misconfigured URL
 - Common causes: incorrect repo owner/name, wrong package name for npm/PyPI badges, expired tokens for private repos
-- Run `/docs-verify links` — it validates badge URLs alongside regular links
+- Run `/pitchdocs:docs-verify links` — it validates badge URLs alongside regular links
 
 ### Cross-renderer Markdown issues
 
@@ -132,11 +132,11 @@ Markdown that renders on GitHub may break on npm or PyPI:
 
 ## llms.txt Sync Issues
 
-`/docs-verify` checks that every file referenced in `llms.txt` exists on disk. Common issues:
+`/pitchdocs:docs-verify` checks that every file referenced in `llms.txt` exists on disk. Common issues:
 
-- **File renamed but llms.txt not updated** — Run `/llms-txt` to regenerate
-- **New file added but not listed** — Run `/llms-txt` to pick up new docs
-- **Orphaned entries** — Files listed in llms.txt that were deleted. Run `/llms-txt` to regenerate a clean version
+- **File renamed but llms.txt not updated** — Run `/pitchdocs:llms-txt` to regenerate
+- **New file added but not listed** — Run `/pitchdocs:llms-txt` to pick up new docs
+- **Orphaned entries** — Files listed in llms.txt that were deleted. Run `/pitchdocs:llms-txt` to regenerate a clean version
 
 ---
 
@@ -168,7 +168,7 @@ When a README.md already exists, PitchDocs reads it first and improves it rather
 
 ### How do I use PitchDocs with a monorepo?
 
-Point commands at specific packages: `/readme packages/api` or `/features packages/ui`. Each package can have its own documentation set.
+Point commands at specific packages: `/pitchdocs:readme packages/api` or `/pitchdocs:features packages/ui`. Each package can have its own documentation set.
 
 ### What if I disagree with PitchDocs' suggestions?
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -26,40 +26,40 @@ Generate the full documentation set for a project you're about to open-source or
 
 1. **Generate README first** — this establishes the project's voice and features:
    ```
-   /readme
+   /pitchdocs:readme
    ```
 
 2. **Audit for missing docs** — check what else the repo needs:
    ```
-   /docs-audit
+   /pitchdocs:docs-audit
    ```
 
 3. **Auto-generate everything missing** — fill all gaps in one go:
    ```
-   /docs-audit fix
+   /pitchdocs:docs-audit fix
    ```
 
 4. **Generate AI context files** — help other developers' AI tools understand your project:
    ```
-   /ai-context
+   /pitchdocs:ai-context
    ```
 
 5. **Generate llms.txt** — make the repo AI-discoverable:
    ```
-   /llms-txt full
+   /pitchdocs:llms-txt full
    ```
 
 6. **Verify everything** — check links, freshness, and quality:
    ```
-   /docs-verify
+   /pitchdocs:docs-verify
    ```
 
 7. **Review the quality score** — aim for 80+ (Grade B or above):
    ```
-   /docs-verify score
+   /pitchdocs:docs-verify score
    ```
 
-**Tip:** If your score is below 80, run `/docs-verify` without arguments to see which dimensions need improvement, then address them individually.
+**Tip:** If your score is below 80, run `/pitchdocs:docs-verify` without arguments to see which dimensions need improvement, then address them individually.
 
 ---
 
@@ -69,22 +69,22 @@ Update documentation after cutting a new version.
 
 1. **Update the changelog** for the new version:
    ```
-   /changelog v1.5.0
+   /pitchdocs:changelog v1.5.0
    ```
 
 2. **Refresh all affected docs** — analyses git changes since the last tag and updates what's needed:
    ```
-   /doc-refresh
+   /pitchdocs:doc-refresh
    ```
 
 3. **Verify nothing is broken** — check for stale content and broken links:
    ```
-   /docs-verify
+   /pitchdocs:docs-verify
    ```
 
 4. **Update badges** — if your version badge is hardcoded, update it in README. If it uses shields.io dynamic badges, it updates automatically.
 
-**Using release-please?** Run `/doc-refresh` before merging the release-please PR. Release-please owns version strings; `/doc-refresh` owns prose, features, metrics, and guides.
+**Using release-please?** Run `/pitchdocs:doc-refresh` before merging the release-please PR. Release-please owns version strings; `/pitchdocs:doc-refresh` owns prose, features, metrics, and guides.
 
 ---
 
@@ -94,21 +94,21 @@ Generate launch content for Dev.to, Hacker News, Reddit, Twitter/X, or awesome l
 
 1. **Ensure README is polished** — launch artifacts are derived from it:
    ```
-   /readme
+   /pitchdocs:readme
    ```
 
 2. **Generate all launch artifacts**:
    ```
-   /launch
+   /pitchdocs:launch
    ```
 
    Or target a specific platform:
    ```
-   /launch devto    # Dev.to article
-   /launch hn       # Hacker News "Show HN" post
-   /launch reddit   # Reddit post templates
-   /launch social   # Twitter/X thread + social preview guide
-   /launch awesome  # Awesome list submission PR
+   /pitchdocs:launch devto    # Dev.to article
+   /pitchdocs:launch hn       # Hacker News "Show HN" post
+   /pitchdocs:launch reddit   # Reddit post templates
+   /pitchdocs:launch social   # Twitter/X thread + social preview guide
+   /pitchdocs:launch awesome  # Awesome list submission PR
    ```
 
 3. **Review before posting** — all artifacts are written to `docs/launch/` for human review. Check for:
@@ -129,17 +129,17 @@ Prevent documentation drift with regular maintenance.
 
 | Trigger | Action |
 |---------|--------|
-| After every release | `/doc-refresh` (or `/doc-refresh v1.x.0`) |
-| Monthly (active projects) | `/docs-verify` to check for staleness |
-| Quarterly | `/features audit` to catch undocumented features |
-| After major refactors | `/ai-context audit` to check context file accuracy |
+| After every release | `/pitchdocs:doc-refresh` (or `/pitchdocs:doc-refresh v1.x.0`) |
+| Monthly (active projects) | `/pitchdocs:docs-verify` to check for staleness |
+| Quarterly | `/pitchdocs:features audit` to catch undocumented features |
+| After major refactors | `/pitchdocs:ai-context audit` to check context file accuracy |
 
 ### Set up Context Guard (Claude Code only)
 
 Install hooks that automatically warn about stale docs:
 
 ```
-/context-guard install
+/pitchdocs:context-guard install
 ```
 
 This adds three hooks:
@@ -149,12 +149,12 @@ This adds three hooks:
 
 Check status anytime:
 ```
-/context-guard status
+/pitchdocs:context-guard status
 ```
 
 ### Add docs verification to CI
 
-Run `/docs-verify ci` to get a CI-friendly output format. Add to GitHub Actions:
+Run `/pitchdocs:docs-verify ci` to get a CI-friendly output format. Add to GitHub Actions:
 
 ```yaml
 # .github/workflows/docs.yml
@@ -174,7 +174,7 @@ jobs:
           args: --no-progress '**.md'
 ```
 
-For PitchDocs-specific checks (quality score, feature coverage, llms.txt sync), run `/docs-verify ci --min-score 70` in a Claude Code session or CI agent.
+For PitchDocs-specific checks (quality score, feature coverage, llms.txt sync), run `/pitchdocs:docs-verify ci --min-score 70` in a Claude Code session or CI agent.
 
 ---
 
@@ -184,27 +184,27 @@ After adding a feature to your codebase, update docs to reflect it.
 
 1. **Check what PitchDocs detects**:
    ```
-   /features audit
+   /pitchdocs:features audit
    ```
 
 2. **Update README features section**:
    ```
-   /readme focus on features
+   /pitchdocs:readme focus on features
    ```
 
 3. **Update affected guides** (if any):
    ```
-   /doc-refresh guides
+   /pitchdocs:doc-refresh guides
    ```
 
 4. **Refresh AI context files**:
    ```
-   /doc-refresh context
+   /pitchdocs:doc-refresh context
    ```
 
 5. **Verify everything is consistent**:
    ```
-   /docs-verify
+   /pitchdocs:docs-verify
    ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -43,18 +43,18 @@
 
 ## Commands
 
-- [/readme](./commands/readme.md): Generate or update a marketing-friendly README.md
-- [/features](./commands/features.md): Extract features from code and translate to benefits
-- [/changelog](./commands/changelog.md): Generate CHANGELOG.md from git history
-- [/roadmap](./commands/roadmap.md): Generate ROADMAP.md from GitHub milestones
-- [/docs-audit](./commands/docs-audit.md): Audit docs completeness against 20+ file checklist with AI context and Diataxis coverage
-- [/llms-txt](./commands/llms-txt.md): Generate llms.txt and llms-full.txt
-- [/user-guide](./commands/user-guide.md): Generate task-oriented user guides with Diataxis classification
-- [/ai-context](./commands/ai-context.md): Generate AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md)
-- [/docs-verify](./commands/docs-verify.md): Verify documentation links, freshness, llms.txt sync, badge URLs, quality score, and security
-- [/launch](./commands/launch.md): Generate platform-specific launch artifacts (Dev.to, HN, Reddit, Twitter, awesome lists)
-- [/doc-refresh](./commands/doc-refresh.md): Refresh all docs after version bumps — CHANGELOG, README features, user guides, AI context files, and llms.txt
-- [/context-guard](./commands/context-guard.md): Install, uninstall, or check status of Context Guard hooks for AI context file freshness (Claude Code only)
+- [/pitchdocs:readme](./commands/readme.md): Generate or update a marketing-friendly README.md
+- [/pitchdocs:features](./commands/features.md): Extract features from code and translate to benefits
+- [/pitchdocs:changelog](./commands/changelog.md): Generate CHANGELOG.md from git history
+- [/pitchdocs:roadmap](./commands/roadmap.md): Generate ROADMAP.md from GitHub milestones
+- [/pitchdocs:docs-audit](./commands/docs-audit.md): Audit docs completeness against 20+ file checklist with AI context and Diataxis coverage
+- [/pitchdocs:llms-txt](./commands/llms-txt.md): Generate llms.txt and llms-full.txt
+- [/pitchdocs:user-guide](./commands/user-guide.md): Generate task-oriented user guides with Diataxis classification
+- [/pitchdocs:ai-context](./commands/ai-context.md): Generate AI IDE context files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md, .windsurfrules, .clinerules, GEMINI.md)
+- [/pitchdocs:docs-verify](./commands/docs-verify.md): Verify documentation links, freshness, llms.txt sync, badge URLs, quality score, and security
+- [/pitchdocs:launch](./commands/launch.md): Generate platform-specific launch artifacts (Dev.to, HN, Reddit, Twitter, awesome lists)
+- [/pitchdocs:doc-refresh](./commands/doc-refresh.md): Refresh all docs after version bumps — CHANGELOG, README features, user guides, AI context files, and llms.txt
+- [/pitchdocs:context-guard](./commands/context-guard.md): Install, uninstall, or check status of Context Guard hooks for AI context file freshness (Claude Code only)
 
 ## Optional
 


### PR DESCRIPTION
## Summary

- Add `pitchdocs:` namespace prefix to all user-facing slash commands across 10 files
- Add plugin usage notes to README, getting-started, and command-reference explaining the prefix requirement
- When installed as a plugin, `/readme` must be invoked as `/pitchdocs:readme` — the short form only works inside the source directory

## Files changed (10)

- `README.md` — commands table (12 rows), quick examples (7), inline mentions (2), comparison table (1)
- `AGENTS.md` — context-guard reference + invocation note in workflow commands section
- `docs/guides/command-reference.md` — all 12 H2 headings + ~35 example lines + preamble note
- `docs/guides/getting-started.md` — namespace note + ~15 code blocks + ~5 inline refs
- `docs/guides/workflows.md` — ~20 code blocks + ~8 inline refs + cadence table
- `docs/guides/customising-output.md` — ~20 code block commands
- `docs/guides/troubleshooting.md` — ~12 inline command refs
- `docs/guides/concepts.md` — 1 inline ref
- `llms.txt` — 12 command link labels
- `.github/copilot-instructions.md` — 1 context-guard ref

## Not changed (intentional)

- `commands/*.md` — command definitions use the registered short name
- `.claude/skills/`, `.claude/agents/` — AI-facing, not user instructions
- `CHANGELOG.md`, `CONTRIBUTING.md` — historical / path references
- `docs/guides/other-ai-tools.md` line 225 — refers to Gemini CLI native command

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors
- [x] Grep verification: no remaining short-form commands in user-facing files (except Gemini CLI native ref)
- [ ] CI checks pass (docs-ci, CodeQL, Socket Security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)