### PR TITLE
docs: mark docs/faq/index.md as protected, add retention guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,14 @@ PitchDocs commands work globally. Advisory features (quality standards, document
 - **This repo** has Standard tier activated — `.claude/rules/doc-standards.md`, `.claude/rules/docs-awareness.md`, and `.claude/agents/docs-freshness.md` are auto-loaded locally
 - **Installed per-project** by `/pitchdocs:activate install strict`: also adds `hooks/content-filter-guard.sh` (Write guard for high-risk OSS files)
 
+## Protected Documentation Files
+
+These files are **load-bearing** for downstream systems and must be retained — only edit them with succinct, focused updates when content genuinely needs to change. Do **not** delete them.
+
+| File | Why It's Load-Bearing | Update Discipline |
+|------|----------------------|-------------------|
+| `docs/faq/index.md` | Source for the marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) **hard-fails** if this directory is missing. Closes [#45](https://github.com/littlebearapps/pitchdocs/issues/45). | Keep ≥7 question-shaped `## ` H2 headings (each ending `?`); preserve `title`/`description` frontmatter only — sync injects `category`, `tool`, dates. Update entries in place when answers drift; don't rewrite wholesale. |
+
 ## AI Context Files
 
 This repository includes context files for multiple AI coding tools:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ These files are **load-bearing** for downstream systems and must be retained —
 
 | File | Why It's Load-Bearing | Update Discipline |
 |------|----------------------|-------------------|
-| `docs/faq/index.md` | Source for the marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) **hard-fails** if this directory is missing. Closes [#45](https://github.com/littlebearapps/pitchdocs/issues/45). | Keep ≥7 question-shaped `## ` H2 headings (each ending `?`); preserve `title`/`description` frontmatter only — sync injects `category`, `tool`, dates. Update entries in place when answers drift; don't rewrite wholesale. |
+| `docs/faq/index.md` | Source for the marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) **hard-fails** if this directory is missing. Closes [#45](https://github.com/littlebearapps/pitchdocs/issues/45). | Keep ≥7 question-shaped H2 headings (`##`) (each ending `?`); preserve `title`/`description` frontmatter only — sync injects `category`, `tool`, dates. Update entries in place when answers drift; don't rewrite wholesale. |
 
 ## AI Context Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ hooks/*.sh                      → 1 opt-in hook script (Claude Code only, inst
 | `upstream-versions.json` | Tracks 7 pinned spec versions — checked monthly by GitHub Action |
 | `llms.txt` | AI-readable content index — must be updated when files are added/removed |
 | `AGENTS.md` | Cross-tool AI context (Codex CLI format) — must stay in sync with skills/commands |
+| `docs/faq/index.md` | **Protected** — source for marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`) hard-fails if this directory is missing. Keep ≥7 question-shaped `## ` H2 headings; update entries in place — never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in AGENTS.md. |
 | `tests/evaluations.json` | 24 command routing test scenarios — used by skill-creator evals |
 
 ## When Modifying This Plugin
@@ -58,6 +59,7 @@ hooks/*.sh                      → 1 opt-in hook script (Claude Code only, inst
 5. **Adding platform support**: Update the `platform-profiles` skill for new platform equivalents. Existing skills reference it via cross-link.
 6. **Bumping version**: Handled automatically by release-please from conventional commit messages
 7. **Before merging a release PR**: Run activation evals from GitHub Actions (`Actions → Activation Evals → Run workflow`) to confirm skill activation hasn't regressed. Target: 80%+.
+8. **Updating `docs/faq/index.md`**: Edit answers in place when content drifts; keep ≥7 question-shaped `## ` H2 headings. **Do not delete or move the file** — the marketing-site sync pipeline hard-fails without it. See [Protected Documentation Files](AGENTS.md#protected-documentation-files).
 
 ## Testing & Validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ hooks/*.sh                      → 1 opt-in hook script (Claude Code only, inst
 | `upstream-versions.json` | Tracks 7 pinned spec versions — checked monthly by GitHub Action |
 | `llms.txt` | AI-readable content index — must be updated when files are added/removed |
 | `AGENTS.md` | Cross-tool AI context (Codex CLI format) — must stay in sync with skills/commands |
-| `docs/faq/index.md` | **Protected** — source for marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`) hard-fails if this directory is missing. Keep ≥7 question-shaped `## ` H2 headings; update entries in place — never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in AGENTS.md. |
+| `docs/faq/index.md` | **Protected** — source for marketing-site FAQPage JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The site's docs-sync (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`) hard-fails if this directory is missing. Keep ≥7 question-shaped H2 headings (`##`); update entries in place — never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in AGENTS.md. |
 | `tests/evaluations.json` | 24 command routing test scenarios — used by skill-creator evals |
 
 ## When Modifying This Plugin
@@ -59,7 +59,7 @@ hooks/*.sh                      → 1 opt-in hook script (Claude Code only, inst
 5. **Adding platform support**: Update the `platform-profiles` skill for new platform equivalents. Existing skills reference it via cross-link.
 6. **Bumping version**: Handled automatically by release-please from conventional commit messages
 7. **Before merging a release PR**: Run activation evals from GitHub Actions (`Actions → Activation Evals → Run workflow`) to confirm skill activation hasn't regressed. Target: 80%+.
-8. **Updating `docs/faq/index.md`**: Edit answers in place when content drifts; keep ≥7 question-shaped `## ` H2 headings. **Do not delete or move the file** — the marketing-site sync pipeline hard-fails without it. See [Protected Documentation Files](AGENTS.md#protected-documentation-files).
+8. **Updating `docs/faq/index.md`**: Edit answers in place when content drifts; keep ≥7 question-shaped H2 headings (`##`). **Do not delete or move the file** — the marketing-site sync pipeline hard-fails without it. See [Protected Documentation Files](AGENTS.md#protected-documentation-files).
 
 ## Testing & Validation
 

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@
 - [Customising Output Guide](./docs/guides/customising-output.md): Steer PitchDocs — prompt patterns, tone control, monorepo support, iterative refinement
 - [Concepts Guide](./docs/guides/concepts.md): How PitchDocs thinks — evidence-based features, GEO, 4-question test, Diataxis, Lobby Principle, Time to Hello World
 - [Troubleshooting & FAQ](./docs/guides/troubleshooting.md): Content filter errors, quality score interpretation, feature extraction issues, badge failures, cross-tool limitations
+- [Frequently Asked Questions](./docs/faq/index.md): Quick answers on installation, AI tool support, data privacy, monorepos, content filter errors, headless mode, updates, and uninstall — also rendered on https://littlebearapps.com/help/pitchdocs/ as `Schema.org/FAQPage` JSON-LD (load-bearing — do not delete)
 - [Other AI Tools Setup](./docs/guides/other-ai-tools.md): Per-tool instructions and compatibility matrix for Codex CLI, Cursor, Windsurf, Cline, Gemini CLI, Aider, and Goose
 - [Untether Integration Guide](./docs/guides/untether-integration.md): Use PitchDocs via Untether's Telegram bridge — hook behaviour, environment variables, security considerations
 


### PR DESCRIPTION
## Summary

Follow-up to #46 (which closed #45 and shipped `docs/faq/index.md`).

This PR adds **succinct retention guidance** so future Claude Code / Codex / Copilot / Cursor sessions in this repo know:

1. **What** `docs/faq/index.md` is — source for the marketing-site `Schema.org/FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`.
2. **Why** it's load-bearing — the `littlebearapps/littlebearapps.com` docs-sync pipeline (`scripts/docs-sync.config.ts`, mapped under `pitchdocs` with `category: faq`) **hard-fails** if the directory is missing; it doesn't skip silently.
3. **How to update it** — edit answers in place, keep ≥7 question-shaped `## ` H2 headings, frontmatter only carries `title` and `description` (sync injects the rest). Never delete.

## Changes

- **`AGENTS.md`** — new "Protected Documentation Files" section just above "AI Context Files".
- **`CLAUDE.md`** — new row in the "Key Files" table pointing to AGENTS.md, plus step 8 in "When Modifying This Plugin".
- **`llms.txt`** — new "Frequently Asked Questions" entry under "Learning & Guides" so AI indexers and the `docs-verify` skill see the file.

11 insertions across 3 files. No other surfaces touched.

## Scope decisions

**Project-canonical only.** Only `AGENTS.md`, `CLAUDE.md`, and `llms.txt` updated. The bridge files (`.cursorrules`, `.windsurfrules`, `.clinerules`, `GEMINI.md`, `.github/copilot-instructions.md`) were already 2 commits behind before #46 and remain so — refreshing them is a separate ContextDocs task (`/contextdocs:context-verify` flagged the drift) and out of scope for this targeted retention note.

**Template untouched.** `rules/docs-awareness.md` and `.claude/rules/docs-awareness.md` were **deliberately not modified** — those propagate to every project that runs `/pitchdocs:activate install`, but FAQ retention is specific to repos that sync to `littlebearapps.com`, not a generic PitchDocs concern.

**Memory.** A project memory note (`memory/protected_files.md`) is also saved in Claude Code's auto-memory so the rule survives across sessions even outside the auto-loaded context window.

## Test plan

- [x] `bash tests/validate-llms-txt.sh` — 0 errors (only pre-existing warnings).
- [x] `bash tests/check-token-budgets.sh` — no new budget violations.
- [x] `bash tests/check-banned-phrases.sh` — clean.
- [ ] CI: lint, links, consistency, validate-plugin, CodeQL, Socket Security all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)