### PR TITLE
docs: refresh AI context bridges with FAQ retention guidance

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -31,8 +31,13 @@ PitchDocs is a Claude Code plugin that generates marketing-quality repository do
 - `.claude-plugin/plugin.json` — plugin manifest
 - `upstream-versions.json` — pinned upstream spec versions
 
+## Protected Files
+
+- `docs/faq/index.md` — load-bearing source for the marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) hard-fails if the directory is missing. Keep ≥7 question-shaped H2 headings (`##`); edit entries in place; never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in `AGENTS.md`.
+
 ## Before Committing
 
 - [ ] Linting passes (`npx markdownlint-cli2 "**/*.md"`)
 - [ ] No secrets or credentials in changed files
 - [ ] Sync files updated if skills/commands changed (README.md, AGENTS.md, llms.txt)
+- [ ] `docs/faq/index.md` not deleted or moved (load-bearing — see Protected Files)

--- a/.cursorrules
+++ b/.cursorrules
@@ -26,6 +26,10 @@ When adding skills or commands, update all of:
 - `llms.txt` (file reference with benefit description)
 - `.github/ISSUE_TEMPLATE/bug_report.yml` (component dropdown)
 
+## Protected Files
+
+`docs/faq/index.md` is load-bearing — it sources the marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) hard-fails if the directory is missing. Keep ≥7 question-shaped H2 headings (`##`); edit entries in place; never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in `AGENTS.md`.
+
 ## Upstream Specs
 
 Pinned in `upstream-versions.json`, checked monthly by `.github/workflows/check-upstream.yml`. Do not bump spec versions without verifying the upstream source.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,3 +25,7 @@ PitchDocs is a Claude Code plugin that generates marketing-quality repository do
 ## Sync Points
 
 When modifying skills or commands, keep these files in sync: README.md, AGENTS.md, llms.txt, and the bug report template component dropdown.
+
+## Protected Files
+
+`docs/faq/index.md` is load-bearing — it sources the marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) hard-fails if the directory is missing. Keep ≥7 question-shaped H2 headings (`##`); edit entries in place; never delete. See [Protected Documentation Files](../AGENTS.md#protected-documentation-files) in `AGENTS.md`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -27,6 +27,10 @@ PitchDocs is a Claude Code plugin that generates marketing-quality repository do
 - `.claude/agents/docs-writer.md` — orchestration agent workflow
 - `upstream-versions.json` — pinned upstream spec versions, checked monthly
 
+## Protected Files
+
+- `docs/faq/index.md` — load-bearing source for the marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) hard-fails if the directory is missing. Keep ≥7 question-shaped H2 headings (`##`); edit entries in place; never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in `AGENTS.md`.
+
 ## Commands
 
 No build or test commands — this is a pure Markdown plugin.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,3 +29,7 @@ No build, test, or deploy commands — this is a pure Markdown plugin. Lint with
 - `hooks/content-filter-guard.sh`: content filter write guard (Claude Code only, installed by `/pitchdocs:activate install strict`)
 - `.claude-plugin/plugin.json`: plugin manifest
 - `upstream-versions.json`: pinned upstream spec versions
+
+## Protected Files
+
+- `docs/faq/index.md` — load-bearing source for the marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`. The docs-sync pipeline (`scripts/docs-sync.config.ts` in `littlebearapps/littlebearapps.com`, mapped under `pitchdocs` with `category: faq`) hard-fails if the directory is missing. Keep ≥7 question-shaped H2 headings (`##`); update entries in place; never delete. See [Protected Documentation Files](AGENTS.md#protected-documentation-files) in `AGENTS.md`.


### PR DESCRIPTION
## Summary

Closes the AI context drift flagged by ContextDocs (5 bridges 2 source commits behind after #46 and #47). Now all 8 AI tools share the same understanding of `docs/faq/index.md`.

Each of the 5 stale bridges gets a single succinct **`## Protected Files`** section cross-linking to the canonical [Protected Documentation Files](AGENTS.md#protected-documentation-files) section in `AGENTS.md`. Bridges stay thin — they reference, they don't duplicate.

| Bridge | Lines added | Section placement |
|--------|-------------|-------------------|
| `GEMINI.md` | +4 | After `## Key Paths` |
| `.cursorrules` | +4 | Between `## File Sync Requirements` and `## Upstream Specs` |
| `.github/copilot-instructions.md` | +4 | After `## Sync Points` |
| `.windsurfrules` | +4 | Between `## Key Files` and `## Commands` |
| `.clinerules` | +5 | Between `## Important Paths` and `## Before Committing` (also adds a checklist item to "Before Committing") |

**Total: 21 insertions across 5 files.** Each addition matches its bridge's existing voice (bullet vs prose, hyphen vs em-dash).

## What every bridge now knows

1. `docs/faq/index.md` is **load-bearing** — source for marketing-site `FAQPage` JSON-LD on `https://littlebearapps.com/help/pitchdocs/`.
2. The `littlebearapps.com` docs-sync (`scripts/docs-sync.config.ts`, `pitchdocs` entry, `category: faq`) **hard-fails** if the directory is missing — it doesn't skip silently.
3. Retention rule: keep ≥7 question-shaped H2 headings (`##`); edit entries in place; never delete.

## Scope decisions

- **Canonical files untouched** — `AGENTS.md`, `CLAUDE.md`, `llms.txt` already current.
- **Template untouched** — `rules/docs-awareness.md` deliberately not modified; FAQ retention is repo-specific (only LBA repos sync to `littlebearapps.com`), not a generic concern that should propagate via `/pitchdocs:activate install`.
- **WIP not touched** — `dist/`, `pitchdocs.json`, `scripts/`, `agents/docs-writer-flat.md`, `.mcp.*.json` are user WIP and explicitly out of scope.

## Test plan

- [x] `bash tests/check-banned-phrases.sh` — CLEAN.
- [x] `bash tests/validate-llms-txt.sh` — 0 errors (only pre-existing orphan warnings).
- [x] `npx markdownlint-cli2` on the 5 bridges — 0 errors.
- [ ] CI: lint, links, consistency, validate-plugin, CodeQL, Socket Security, CodeRabbit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)